### PR TITLE
chore(ci): fix dispatch_docs

### DIFF
--- a/.github/workflows/dispatch_docs.yml
+++ b/.github/workflows/dispatch_docs.yml
@@ -1,4 +1,4 @@
-name: v2raya_gui-docker
+name: dispatch_docs
 
 on:
   release:
@@ -14,4 +14,5 @@ jobs:
         with:
           workflow: Pages CI
           repo: v2rayA/v2raya.github.io
+          ref: main
           token: ${{ secrets.DISPATCH_BUILD_TOKEN }}


### PR DESCRIPTION
According to https://github.com/benc-uk/workflow-dispatch/blob/master/action.yaml#L14-L16, it is necessary to specify the branch to be triggered the workflow dispatch.