### PR TITLE
fix: 当V2ray意外退出后，修改系统状态

### DIFF
--- a/service/core/v2ray/process.go
+++ b/service/core/v2ray/process.go
@@ -73,7 +73,7 @@ func NewProcess(tmpl *Template) (process *Process, err error) {
 	var unexpectedExiting bool
 	go func() {
 		p, e := proc.Wait()
-		defer ProcessManager.Stop(true)
+		defer ProcessManager.Stop(false)
 		if process.procCancel == nil {
 			// canceled by v2rayA
 			return

--- a/service/core/v2ray/process.go
+++ b/service/core/v2ray/process.go
@@ -73,6 +73,7 @@ func NewProcess(tmpl *Template) (process *Process, err error) {
 	var unexpectedExiting bool
 	go func() {
 		p, e := proc.Wait()
+		defer ProcessManager.Stop(true)
 		if process.procCancel == nil {
 			// canceled by v2rayA
 			return


### PR DESCRIPTION
fix https://github.com/v2rayA/v2rayA/issues/380
当V2ray意外退出后，iptables和dns，以及右上角的状态并不会更新，开启透明代理后可能导致系统断网