### PR TITLE
optimize: 使用预压缩的前端文件以节省体积

### DIFF
--- a/build-in-pwsh.ps1
+++ b/build-in-pwsh.ps1
@@ -1,3 +1,27 @@
+Function Gzip-File([ValidateScript({Test-Path $_})][string]$File){
+ 
+    $srcFile = Get-Item -Path $File
+    $newFileName = "$($srcFile.FullName).gz"
+ 
+    try
+    {
+        $srcFileStream = New-Object System.IO.FileStream($srcFile.FullName,([IO.FileMode]::Open),([IO.FileAccess]::Read),([IO.FileShare]::Read))
+        $dstFileStream = New-Object System.IO.FileStream($newFileName,([IO.FileMode]::Create),([IO.FileAccess]::Write),([IO.FileShare]::None))
+        $gzip = New-Object System.IO.Compression.GZipStream($dstFileStream,[System.IO.Compression.CompressionMode]::Compress)
+        $srcFileStream.CopyTo($gzip)
+    } 
+    catch
+    {
+        Write-Host "$_.Exception.Message" -ForegroundColor Red
+    }
+    finally
+    {
+        $gzip.Dispose()
+        $srcFileStream.Dispose()
+        $dstFileStream.Dispose()
+    }
+}
+
 Set-PSDebug -Trace 1
 
 ## Check OS
@@ -56,6 +80,12 @@ else {
             Set-Location -path "$guiPath"
             yarn
             yarn build
+            Get-ChildItem "$SHELL_FOLDER/service/server/router/web" -recurse |Where-Object{$_.PSIsContainer -eq $False}|ForEach-Object -Process{
+                if($_.Extension -ne ".png" -and $_.Extension -ne ".gz" -and $_.Name -ne "index.html"){
+                    Gzip-File($_.FullName)
+                    Remove-Item -Path $_.FullName
+                }
+            }
             $corePath = $SHELL_FOLDER + "/service"
             Set-Location -path "$corePath"
             go build -ldflags "-X github.com/v2rayA/v2rayA/conf.Version=$version -s -w" -o "$SHELL_FOLDER/$v2rayaBin"

--- a/build.sh
+++ b/build.sh
@@ -11,4 +11,10 @@ else
   version="unstable"
 fi
 cd "$SHELL_FOLDER"/gui && yarn && OUTPUT_DIR="$SHELL_FOLDER"/service/server/router/web yarn build
+for file in $(find  "$SHELL_FOLDER"/service/server/router/web |grep -v png |grep -v index.html|grep -v .gz)
+do
+  if [ ! -d $file ];then
+    gzip -9 $file
+  fi
+done
 cd "$SHELL_FOLDER"/service && CGO_ENABLED=0 go build -ldflags "-X github.com/v2rayA/v2rayA/conf.Version=$version -s -w" -o "$CWD"/v2raya

--- a/gui/src/locales/en.js
+++ b/gui/src/locales/en.js
@@ -259,7 +259,7 @@ export default {
   version: {
     higherVersionNeeded:
       "This operation need higher version of v2rayA than {version}",
-    v2rayInvalid: "v2ray-core may not be installed correctly"
+    v2rayInvalid: "geosite.dat, geoip.dat or v2ray-core may not be installed correctly"
   },
   about: `<p>v2rayA is a web GUI client of V2Ray. Frontend is built with Vue.js and backend is built with golang.</p>
           <p class="about-small">Default ports:</p>

--- a/gui/src/locales/zh.js
+++ b/gui/src/locales/zh.js
@@ -254,8 +254,8 @@ export default {
     message: "时延测试往往需要花费较长时间，请耐心等待"
   },
   version: {
-    higherVersionNeeded: "该操作需要v2rayA的版本高于{version}",
-    v2rayInvalid: "检测到v2ray-core可能未正确安装，请检查"
+    higherVersionNeeded: "该操作需要 v2rayA 的版本高于{version}",
+    v2rayInvalid: "检测到 geosite.dat, geoip.dat 文件或 v2ray-core 可能未正确安装，请检查"
   },
   about: `<p>v2rayA是V2Ray的一个Web客户端，前端使用Vue.js构建，后端使用Golang构建。</p>
           <p class="about-small">默认端口：</p>

--- a/gui/vue.config.js
+++ b/gui/vue.config.js
@@ -48,7 +48,7 @@ module.exports = {
     port: 8081
   },
 
-  publicPath: "./",
+  publicPath: "./static/",
   // publicPath:process.env.NODE_ENV === 'production'
   // ? '/v2rayA/'
   // : '/',

--- a/service/go.mod
+++ b/service/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/ugorji/go/codec v1.1.7 // indirect
+	github.com/vearutop/statigz v1.1.7 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	gitlab.com/yawning/chacha20.git v0.0.0-20190903091407-6d1cb28dc72c // indirect
 	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect

--- a/service/go.sum
+++ b/service/go.sum
@@ -221,6 +221,8 @@ github.com/v2rayA/shadowsocksR v1.0.4 h1:65Ltdy+I/DnlkQTJj+R+X85zhZ63ORE1Roy+agA
 github.com/v2rayA/shadowsocksR v1.0.4/go.mod h1:CyOhDLy8/AKedsi16xRYAMmkxSCH1ukJPaacaTdRfQg=
 github.com/v2rayA/v2ray-lib v0.0.0-20211227083129-d4f59fbf62b8 h1:awvgHyZyQnrz25ibNcJoCF2+UWUzgDOVXUc593iQO34=
 github.com/v2rayA/v2ray-lib v0.0.0-20211227083129-d4f59fbf62b8/go.mod h1:58r5UEMOLW9jmayL39nq4yyURyLb2bT06+vvWRaa8gI=
+github.com/vearutop/statigz v1.1.7 h1:/36vj7srdvhJUwV2tR4rXWhNyO7O6hRyNtpPWnH5fN0=
+github.com/vearutop/statigz v1.1.7/go.mod h1:Shq1bNLzz9IRa6KykXy/1ubPrHehv0oP27cKyiHuj4o=
 github.com/xtaci/smux v1.5.15 h1:6hMiXswcleXj5oNfcJc+DXS8Vj36XX2LaX98udog6Kc=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPRg=

--- a/service/server/router/index.go
+++ b/service/server/router/index.go
@@ -14,6 +14,7 @@ import (
 	"github.com/v2rayA/v2rayA/pkg/server/reqCache"
 	"github.com/v2rayA/v2rayA/pkg/util/log"
 	"github.com/v2rayA/v2rayA/server/controller"
+	"github.com/vearutop/statigz"
 	"io"
 	"io/fs"
 	"net"
@@ -61,27 +62,14 @@ func ServeGUI(engine *gin.Engine) {
 	r := engine.Use(gzip.Gzip(gzip.DefaultCompression))
 	webDir := conf.GetEnvironmentConfig().WebDir
 	if webDir == "" {
-		webFS := relativeFS{
-			root:        webRoot,
-			relativeDir: "web",
+		webFS, err := fs.Sub(webRoot, "web")
+		if err != nil {
+			log.Fatal("%v", err)
 		}
-		fs.WalkDir(webFS, "/", func(path string, info fs.DirEntry, err error) error {
-			if path == "/" {
-				return nil
-			}
-			if info.IsDir() {
-				r.StaticFS("/"+info.Name(), http.FS(relativeFS{
-					root:        webFS,
-					relativeDir: path,
-				}))
-				return filepath.SkipDir
-			}
-			r.GET("/"+info.Name(), func(ctx *gin.Context) {
-				ctx.FileFromFS(path, http.FS(webFS))
-			})
-			return nil
+		ss := http.StripPrefix("/static", statigz.FileServer(webFS.(fs.ReadDirFS)))
+		r.GET("/static/*w", func(c *gin.Context) {
+			ss.ServeHTTP(c.Writer, c.Request)
 		})
-
 		f, err := webFS.Open("index.html")
 		if err != nil {
 			log.Fatal("%v", err)
@@ -101,10 +89,10 @@ func ServeGUI(engine *gin.Engine) {
 					return nil
 				}
 				if info.IsDir() {
-					r.Static("/"+info.Name(), path)
+					r.Static("/static/"+info.Name(), path)
 					return filepath.SkipDir
 				}
-				r.StaticFile("/"+info.Name(), path)
+				r.StaticFile("/static/"+info.Name(), path)
 				return nil
 			})
 


### PR DESCRIPTION
提前将前端静态文件压缩后再embed到二进制中，可以有效减小二进制文件体积，同时减少运行时压缩开销，这在嵌入式设备上至关重要。
在我的设备上测试，二进制体积可减少25%:
![Screenshot_20220125_013231](https://user-images.githubusercontent.com/19235246/150834383-185723c9-922f-4828-bc23-50ac558548e5.png)
唯一的问题可能是需要修改GUI的asset路径，这可能造成不兼容的改动

关于为什么brotli反而压缩率下降了：
```
Using brotli adds about 260 KB to binary size, that's why it is moved to a separate package.
```