### PR TITLE
feat: Add port for socks5 proxy with rule

### DIFF
--- a/gui/src/components/modalCustomPorts.vue
+++ b/gui/src/components/modalCustomPorts.vue
@@ -45,6 +45,18 @@
           ></b-input>
         </b-field>
         <b-field
+            :label="$t('customAddressPort.portSocks5WithPac')"
+            label-position="on-border"
+        >
+          <b-input
+              v-model="table.socks5WithPac"
+              placeholder="0"
+              type="number"
+              min="0"
+              required
+          ></b-input>
+        </b-field>
+        <b-field
           :label="$t('customAddressPort.portHttpWithPac')"
           label-position="on-border"
         >
@@ -123,6 +135,7 @@ export default {
       backendAddress: "http://localhost:2017",
       socks5: "20170",
       http: "20171",
+      socks5WithPac: "0",
       httpWithPac: "20172",
       vlessGrpc: "0",
       vlessGrpcLink: ""
@@ -170,6 +183,7 @@ export default {
           data: {
             socks5: parseInt(this.table.socks5),
             http: parseInt(this.table.http),
+            socks5WithPac: parseInt(this.table.socks5WithPac),
             httpWithPac: parseInt(this.table.httpWithPac),
             vlessGrpc: parseInt(this.table.vlessGrpc)
           }

--- a/gui/src/locales/en.js
+++ b/gui/src/locales/en.js
@@ -157,6 +157,7 @@ export default {
     serviceAddress: "Address of Service",
     portSocks5: "Port of SOCKS5",
     portHttp: "Port of HTTP",
+    portSocks5WithPac: "Port of SOCKS5(with Rule)",
     portHttpWithPac: "Port of HTTP(with Rule)",
     portVlessGrpc: "Port of VLESS-GRPC(with Rule)",
     portVlessGrpcPrompt: "Link of VLESS-GRPC port",

--- a/gui/src/locales/zh.js
+++ b/gui/src/locales/zh.js
@@ -156,6 +156,7 @@ export default {
     serviceAddress: "服务端地址",
     portSocks5: "socks5端口",
     portHttp: "http端口",
+    portSocks5WithPac: "socks5端口(带分流规则)",
     portHttpWithPac: "http端口(带分流规则)",
     portVlessGrpc: "VLESS-GRPC端口(带分流规则)",
     portVlessGrpcLink: "VLESS-GRPC端口链接",

--- a/service/core/v2ray/templateJson.go
+++ b/service/core/v2ray/templateJson.go
@@ -37,7 +37,7 @@ const TemplateJson = `
             "tag": "http"
         },
         {
-            "port": 20173,
+            "port": 0,
             "listen": "0.0.0.0",
             "protocol": "socks",
             "sniffing": {

--- a/service/core/v2ray/templateJson.go
+++ b/service/core/v2ray/templateJson.go
@@ -37,6 +37,26 @@ const TemplateJson = `
             "tag": "http"
         },
         {
+            "port": 20173,
+            "listen": "0.0.0.0",
+            "protocol": "socks",
+            "sniffing": {
+                "enabled": true,
+                "destOverride": [
+                    "http",
+                    "tls"
+                ]
+            },
+            "settings": {
+                "auth": "noauth",
+                "udp": true,
+                "ip": null,
+                "clients": null
+            },
+            "streamSettings": null,
+            "tag": "rule-socks"
+        },
+        {
             "port": 20172,
             "listen": "0.0.0.0",
             "protocol": "http",
@@ -47,7 +67,7 @@ const TemplateJson = `
                     "tls"
                 ]
             },
-            "tag": "rule"
+            "tag": "rule-http"
         },
         {
             "listen": "0.0.0.0",

--- a/service/core/v2ray/v2rayTmpl.go
+++ b/service/core/v2ray/v2rayTmpl.go
@@ -589,7 +589,7 @@ func (t *Template) AppendRoutingRuleByMode(mode configure.RulePortMode, inbounds
 }
 
 func (t *Template) setRulePortRouting() error {
-	return t.AppendRoutingRuleByMode(t.Setting.RulePortMode, []string{"rule"})
+	return t.AppendRoutingRuleByMode(t.Setting.RulePortMode, []string{"rule-http", "rule-socks"})
 }
 func parseRoutingA(t *Template, routingInboundTags []string) error {
 	lines := strings.Split(configure.GetRoutingA(), "\n")
@@ -1011,8 +1011,9 @@ func (t *Template) setInbound() error {
 	if p != nil {
 		t.Inbounds[0].Port = p.Socks5
 		t.Inbounds[1].Port = p.Http
-		t.Inbounds[2].Port = p.HttpWithPac
-		vlessGrpc := &t.Inbounds[3]
+		t.Inbounds[2].Port = p.Socks5WithPac
+		t.Inbounds[3].Port = p.HttpWithPac
+		vlessGrpc := &t.Inbounds[4]
 		vlessGrpc.Port = p.VlessGrpc
 		if p.VlessGrpc > 0 {
 			if err := service.CheckGrpcSupported(); err != nil {

--- a/service/core/v2ray/v2rayTmpl.go
+++ b/service/core/v2ray/v2rayTmpl.go
@@ -589,6 +589,8 @@ func (t *Template) AppendRoutingRuleByMode(mode configure.RulePortMode, inbounds
 }
 
 func (t *Template) setRulePortRouting() error {
+	// append rule-http and rule-socks no mather if they are enabled
+	// because "The Same as the Rule Port" may need them
 	return t.AppendRoutingRuleByMode(t.Setting.RulePortMode, []string{"rule-http", "rule-socks"})
 }
 func parseRoutingA(t *Template, routingInboundTags []string) error {
@@ -797,7 +799,7 @@ func parseRoutingA(t *Template, routingInboundTags []string) error {
 	t.Routing.Rules = append(t.Routing.Rules, coreObj.RoutingRule{
 		Type:        "field",
 		OutboundTag: defaultOutbound,
-		InboundTag:  []string{"rule"},
+		InboundTag:  []string{"rule-http", "rule-socks"},
 	})
 	return nil
 }
@@ -814,7 +816,7 @@ func (t *Template) setTransparentRouting() (err error) {
 		for i := range t.Routing.Rules {
 			ok := false
 			for _, in := range t.Routing.Rules[i].InboundTag {
-				if in == "rule" {
+				if in == "rule-http" {
 					ok = true
 					break
 				}
@@ -1449,7 +1451,7 @@ func (t *Template) setVlessGrpcRouting() {
 	for i := range t.Routing.Rules {
 		var bHasRule bool
 		for _, tag := range t.Routing.Rules[i].InboundTag {
-			if tag == "rule" {
+			if tag == "rule-http" {
 				bHasRule = true
 			}
 		}

--- a/service/db/configure/configure.go
+++ b/service/db/configure/configure.go
@@ -33,10 +33,11 @@ func New() *Configure {
 		Setting:          NewSetting(),
 		Accounts:         map[string]string{},
 		Ports: Ports{
-			Socks5:      20170,
-			Http:        20171,
-			HttpWithPac: 20172,
-			VlessGrpc:   0,
+			Socks5:        20170,
+			Socks5WithPac: 0,
+			Http:          20171,
+			HttpWithPac:   20172,
+			VlessGrpc:     0,
 		},
 		InternalDnsList: nil,
 		ExternalDnsList: nil,
@@ -260,6 +261,7 @@ func GetPortsNotNil() *Ports {
 		p = new(Ports)
 		p.Socks5 = 20170
 		p.Http = 20171
+		p.Socks5WithPac = 0
 		p.HttpWithPac = 20172
 		p.VlessGrpc = 0
 	}

--- a/service/db/configure/ports.go
+++ b/service/db/configure/ports.go
@@ -1,8 +1,9 @@
 package configure
 
 type Ports struct {
-	Socks5      int `json:"socks5"`
-	Http        int `json:"http"`
-	HttpWithPac int `json:"httpWithPac"`
-	VlessGrpc   int `json:"vlessGrpc"`
+	Socks5        int `json:"socks5"`
+	Http          int `json:"http"`
+	Socks5WithPac int `json:"socks5WithPac"`
+	HttpWithPac   int `json:"httpWithPac"`
+	VlessGrpc     int `json:"vlessGrpc"`
 }

--- a/service/server/service/ports.go
+++ b/service/server/service/ports.go
@@ -24,6 +24,10 @@ func SetPorts(ports *configure.Ports) (err error) {
 		set[ports.Http] = struct{}{}
 		cnt++
 	}
+	if ports.Socks5WithPac != 0 {
+		set[ports.Socks5WithPac] = struct{}{}
+		cnt++
+	}
 	if ports.HttpWithPac != 0 {
 		set[ports.HttpWithPac] = struct{}{}
 		cnt++
@@ -46,6 +50,12 @@ func SetPorts(ports *configure.Ports) (err error) {
 		origin.Http = ports.Http
 		if origin.Http != 0 {
 			detectSyntax = append(detectSyntax, strconv.Itoa(origin.Http)+":tcp")
+		}
+	}
+	if ports.Socks5WithPac != origin.Socks5WithPac {
+		origin.Socks5WithPac = ports.Socks5WithPac
+		if origin.Socks5WithPac != 0 {
+			detectSyntax = append(detectSyntax, strconv.Itoa(origin.Socks5WithPac)+":tcp,udp")
 		}
 	}
 	if ports.HttpWithPac != origin.HttpWithPac {


### PR DESCRIPTION
相关issue #88  

为了实现局域网内的全局加速，我通过路由器上的ipt2socks将需要加速的流量转发到v2raya的socks代理上，但这些流量需要在v2raya中进一步进行分流（如NetFlix等）。

目前，可以通过RoutingA规则实现，大致如下：
```
inboundTag(socks, rule) && domain(geosite:netflix) -> netflix
```
但是编写起来比较麻烦，也不太美观。

因此，参考httpWithPac，实现了socks5WithPac，用于对socks5代理流量进行分流。
