### PR TITLE
fix vmess sni

### DIFF
--- a/service/core/serverObj/v2ray.go
+++ b/service/core/serverObj/v2ray.go
@@ -3,16 +3,18 @@ package serverObj
 import (
 	"encoding/base64"
 	"fmt"
-	jsoniter "github.com/json-iterator/go"
-	"github.com/v2rayA/v2rayA/common"
-	"github.com/v2rayA/v2rayA/core/coreObj"
-	"github.com/v2rayA/v2rayA/core/v2ray/service"
-	"github.com/v2rayA/v2rayA/pkg/util/log"
 	"net"
 	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/tidwall/gjson"
+	"github.com/v2rayA/v2rayA/common"
+	"github.com/v2rayA/v2rayA/core/coreObj"
+	"github.com/v2rayA/v2rayA/core/v2ray/service"
+	"github.com/v2rayA/v2rayA/pkg/util/log"
 )
 
 func init() {
@@ -158,6 +160,12 @@ func ParseVmessURL(vmess string) (data *V2Ray, err error) {
 		}
 	} else {
 		err = jsoniter.Unmarshal([]byte(raw), &info)
+		if info.Host == "" {
+			sni := gjson.Get(raw, "sni")
+			if sni.Exists() {
+				info.Host = sni.String()
+			}
+		}
 		if err != nil {
 			return
 		}

--- a/service/core/serverObj/v2ray.go
+++ b/service/core/serverObj/v2ray.go
@@ -160,14 +160,14 @@ func ParseVmessURL(vmess string) (data *V2Ray, err error) {
 		}
 	} else {
 		err = jsoniter.Unmarshal([]byte(raw), &info)
+		if err != nil {
+			return
+		}
 		if info.Host == "" {
 			sni := gjson.Get(raw, "sni")
 			if sni.Exists() {
 				info.Host = sni.String()
 			}
-		}
-		if err != nil {
-			return
 		}
 	}
 	// correct the wrong vmess as much as possible


### PR DESCRIPTION
修复Vmess json格式时，订阅参数中有sni无host时无法正确识别
#496 