### PR TITLE
Support SOCKS as outbound server.

### DIFF
--- a/gui/src/components/modalServer.vue
+++ b/gui/src/components/modalServer.vue
@@ -696,19 +696,19 @@
           </b-field>
         </b-tab-item>
 
-        <b-tab-item label="SOCKS">
+        <b-tab-item label="SOCKS5">
           <b-field label="Name" label-position="on-border">
             <b-input
-              ref="socks_name"
-              v-model="socks.name"
+              ref="socks5_name"
+              v-model="socks5.name"
               :placeholder="$t('configureServer.servername')"
               expanded
             />
           </b-field>
           <b-field label="Host" label-position="on-border">
             <b-input
-              ref="socks_host"
-              v-model="socks.host"
+              ref="socks5_host"
+              v-model="socks5.host"
               required
               placeholder="IP / HOST"
               expanded
@@ -716,8 +716,8 @@
           </b-field>
           <b-field label="Port" label-position="on-border">
             <b-input
-              ref="socks_port"
-              v-model="socks.port"
+              ref="socks5_port"
+              v-model="socks5.port"
               required
               :placeholder="$t('configureServer.port')"
               type="number"
@@ -726,16 +726,16 @@
           </b-field>
           <b-field label="Username" label-position="on-border">
             <b-input
-              ref="socks_username"
-              v-model="socks.username"
+              ref="socks5_username"
+              v-model="socks5.username"
               :placeholder="$t('configureServer.username')"
               expanded
             />
           </b-field>
           <b-field label="Password" label-position="on-border">
             <b-input
-              ref="socks_password"
-              v-model="socks.password"
+              ref="socks5_password"
+              v-model="socks5.password"
               :placeholder="$t('configureServer.password')"
               expanded
             />
@@ -847,12 +847,12 @@ export default {
       protocol: "http",
       name: ""
     },
-    socks: {
+    socks5: {
       username: "",
       password: "",
       host: "",
       port: "",
-      protocol: "socks",
+      protocol: "socks5",
       name: ""
     },
     tabChoice: 0,
@@ -934,9 +934,9 @@ export default {
             this.http = this.resolveURL(res.data.data.sharingAddress);
             this.tabChoice = 5;
           } else if (
-            res.data.data.sharingAddress.toLowerCase().startsWith("socks://")
+            res.data.data.sharingAddress.toLowerCase().startsWith("socks5://")
           ) {
-            this.socks = this.resolveURL(res.data.data.sharingAddress);
+            this.socks5 = this.resolveURL(res.data.data.sharingAddress);
             this.tabChoice = 6;
           }
           this.$nextTick(() => {
@@ -1159,7 +1159,7 @@ export default {
           protocol: u.protocol,
           name: decodeURIComponent(u.hash)
         };
-      } else if (url.toLowerCase().startsWith("socks://")) {
+      } else if (url.toLowerCase().startsWith("socks5://")) {
         let u = parseURL(url);
         return {
           username: decodeURIComponent(u.username),
@@ -1332,9 +1332,9 @@ export default {
             });
           }
           return generateURL(tmp);
-        case "socks":
+        case "socks5":
           tmp = {
-            protocol: srcObj.protocol + "-proxy",
+            protocol: "socks5",
             host: srcObj.host,
             port: srcObj.port,
             hash: srcObj.name
@@ -1401,7 +1401,7 @@ export default {
         if (this.tabChoice === 5 && !k.startsWith("http_")) {
           continue;
         }
-        if (this.tabChoice === 6 && !k.startsWith("socks_")) {
+        if (this.tabChoice === 6 && !k.startsWith("socks5_")) {
           continue;
         }
         let x = this.$refs[k];
@@ -1453,7 +1453,7 @@ export default {
       } else if (this.tabChoice === 5) {
         coded = this.generateURL(this.http);
       } else if (this.tabChoice === 6) {
-        coded = this.generateURL(this.socks);
+        coded = this.generateURL(this.socks5);
       }
       this.$emit("submit", coded);
     }

--- a/service/core/serverObj/socks.go
+++ b/service/core/serverObj/socks.go
@@ -9,12 +9,8 @@ import (
 )
 
 func init() {
-	FromLinkRegister("socks-proxy", NewSOCKS)
-	FromLinkRegister("socks", NewSOCKS)
-	EmptyRegister("socks-proxy", func() (ServerObj, error) {
-		return new(SOCKS), nil
-	})
-	EmptyRegister("socks", func() (ServerObj, error) {
+	FromLinkRegister("socks5", NewSOCKS)
+	EmptyRegister("socks5", func() (ServerObj, error) {
 		return new(SOCKS), nil
 	})
 }
@@ -51,8 +47,8 @@ func ParseSocksURL(u string) (data *SOCKS, err error) {
 		data.Password, _ = t.User.Password()
 	}
 	switch t.Scheme {
-	case "socks", "socks-proxy":
-		data.Protocol = "socks"
+	case "socks5":
+		data.Protocol = "socks5"
 		if data.Port == 0 {
 			data.Port = 1080
 		}

--- a/service/core/serverObj/socks.go
+++ b/service/core/serverObj/socks.go
@@ -1,0 +1,133 @@
+package serverObj
+
+import (
+	"net"
+	"net/url"
+	"strconv"
+
+	"github.com/v2rayA/v2rayA/core/coreObj"
+)
+
+func init() {
+	FromLinkRegister("socks-proxy", NewSOCKS)
+	FromLinkRegister("socks", NewSOCKS)
+	EmptyRegister("socks-proxy", func() (ServerObj, error) {
+		return new(SOCKS), nil
+	})
+	EmptyRegister("socks", func() (ServerObj, error) {
+		return new(SOCKS), nil
+	})
+}
+
+type SOCKS struct {
+	Name     string `json:"name"`
+	Server   string `json:"server"`
+	Port     int    `json:"port"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Protocol string `json:"protocol"`
+}
+
+func NewSOCKS(link string) (ServerObj, error) {
+	return ParseSocksURL(link)
+}
+
+func ParseSocksURL(u string) (data *SOCKS, err error) {
+	t, err := url.Parse(u)
+	if err != nil {
+		return nil, InvalidParameterErr
+	}
+	port, err := strconv.Atoi(t.Port())
+	if err != nil {
+		return nil, InvalidParameterErr
+	}
+	data = &SOCKS{
+		Name:   t.Fragment,
+		Server: t.Hostname(),
+		Port:   port,
+	}
+	if t.User != nil && len(t.User.String()) > 0 {
+		data.Username = t.User.Username()
+		data.Password, _ = t.User.Password()
+	}
+	switch t.Scheme {
+	case "socks", "socks-proxy":
+		data.Protocol = "socks"
+		if data.Port == 0 {
+			data.Port = 1080
+		}
+	default:
+		data.Protocol = t.Scheme
+	}
+	return data, nil
+}
+
+func (h *SOCKS) Configuration(info PriorInfo) (c Configuration, err error) {
+	var users []coreObj.OutboundUser
+	if h.Username != "" && h.Password != "" {
+		users = []coreObj.OutboundUser{
+			{
+				User: h.Username,
+				Pass: h.Password,
+			},
+		}
+	}
+	o := coreObj.OutboundObject{
+		Tag:      info.Tag,
+		Protocol: "socks",
+		Settings: coreObj.Settings{
+			Servers: []coreObj.Server{{
+				Address: h.Server,
+				Port:    h.Port,
+				Users:   users,
+			}},
+		},
+	}
+	return Configuration{
+		CoreOutbound: o,
+		PluginChain:  "",
+		UDPSupport:   true,
+	}, nil
+}
+
+func (h *SOCKS) ExportToURL() string {
+	var user *url.Userinfo
+	if h.Username != "" && h.Password != "" {
+		user = url.UserPassword(h.Username, h.Password)
+	}
+	u := &url.URL{
+		Scheme:   h.Protocol,
+		User:     user,
+		Host:     net.JoinHostPort(h.Server, strconv.Itoa(h.Port)),
+		Fragment: h.Name,
+	}
+	return u.String()
+}
+
+func (h *SOCKS) NeedPlugin() bool {
+	return false
+}
+
+func (h *SOCKS) ProtoToShow() string {
+	return h.Protocol
+}
+
+func (h *SOCKS) GetProtocol() string {
+	return h.Protocol
+}
+
+func (h *SOCKS) GetHostname() string {
+	return h.Server
+}
+
+func (h *SOCKS) GetPort() int {
+	return h.Port
+}
+
+func (h *SOCKS) GetName() string {
+	return h.Name
+}
+
+func (h *SOCKS) SetName(name string) {
+	h.Name = name
+}

--- a/service/server/service/import.go
+++ b/service/server/service/import.go
@@ -39,7 +39,7 @@ func Import(url string, which *configure.Which) (err error) {
 		strings.HasPrefix(url, "trojan-go://") ||
 		strings.HasPrefix(url, "http-proxy://") ||
 		strings.HasPrefix(url, "https-proxy://") ||
-		strings.HasPrefix(url, "socks-proxy://") ||
+		strings.HasPrefix(url, "socks5://") ||
 		strings.HasPrefix(url, "http2://") {
 		var obj serverObj.ServerObj
 		obj, err = ResolveURL(url)

--- a/service/server/service/import.go
+++ b/service/server/service/import.go
@@ -39,6 +39,7 @@ func Import(url string, which *configure.Which) (err error) {
 		strings.HasPrefix(url, "trojan-go://") ||
 		strings.HasPrefix(url, "http-proxy://") ||
 		strings.HasPrefix(url, "https-proxy://") ||
+		strings.HasPrefix(url, "socks-proxy://") ||
 		strings.HasPrefix(url, "http2://") {
 		var obj serverObj.ServerObj
 		obj, err = ResolveURL(url)


### PR DESCRIPTION
This PR adds support for using SOCKS as a outbound server.

A new `serverObj` and corresponding GUI parts are added.

They basically mimic the existing `http` serverObj implementations with few changes, there should be no confliction to current code base.

By having SOCKS as an outbound, v2raya can chain unsupported proxy with better performance and UDP support.


#### Tested
- [x] V2ray/X-ray core as v2raya backend.
- [x] V2ray as SOCKS server, with and without `password` authentication.
- [x] Clash as SOCKS server, without authentication.

Thank you! Please review.