### PR TITLE
Provide a new implement way of shadowsocks plugin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ node_modules
 /PKGBUILD
 /go.mod
 /go.sum
+
+# Virtualenv
+.env

--- a/gui/src/components/modalServer.vue
+++ b/gui/src/components/modalServer.vue
@@ -314,6 +314,32 @@
             </b-select>
           </b-field>
           <b-field
+            v-if="ss.plugin === 'simple-obfs' || ss.plugin === 'v2ray-plugin'"
+            label-position="on-border"
+            class="with-icon-alert"
+          >
+            <template slot="label">
+              Impl
+              <b-tooltip
+                type="is-dark"
+                :label="$t('setting.messages.ssPluginImpl')"
+                multilined
+                position="is-right"
+              >
+                <b-icon
+                  size="is-samll"
+                  icon=" iconfont icon-help-circle-outline"
+                  style="position:relative;top:2px;right:3px;font-weight:normal"
+                />
+              </b-tooltip>
+            </template>
+            <b-select ref="ss_plugin_impl" v-model="ss.impl" expanded>
+              <option value="">{{ $t("setting.options.default") }}</option>
+              <option value="chained">chained</option>
+              <option value="transport">transport</option>
+            </b-select>
+          </b-field>
+          <b-field
             v-show="ss.plugin === 'simple-obfs'"
             label="Obfs"
             label-position="on-border"
@@ -808,7 +834,8 @@ export default {
       server: "",
       port: "",
       name: "",
-      protocol: "ss"
+      protocol: "ss",
+      impl: ""
     },
     ssr: {
       method: "aes-128-cfb",
@@ -1030,7 +1057,8 @@ export default {
           name: u.hash,
           obfs: "http",
           plugin: "",
-          protocol: "ss"
+          protocol: "ss",
+          impl: ""
         };
         if (u.params.plugin) {
           u.params.plugin = decodeURIComponent(u.params.plugin);
@@ -1066,6 +1094,8 @@ export default {
                 break;
               case "tls":
                 obj.tls = "tls";
+              case "impl":
+                obj.impl = a[1];
             }
           }
         }
@@ -1272,11 +1302,17 @@ export default {
                 }
                 plugin.push("path=" + srcObj.path);
               }
+              if (srcObj.impl) {
+                plugin.push("impl=" + srcObj.impl);
+              }
             } else {
               plugin.push("obfs=" + srcObj.obfs);
               plugin.push("obfs-host=" + srcObj.host);
               if (srcObj.obfs === "http") {
                 plugin.push("obfs-path=" + srcObj.path);
+              }
+              if (srcObj.impl) {
+                plugin.push("impl=" + srcObj.impl);
               }
             }
             tmp += `?plugin=${encodeURIComponent(plugin.join(";"))}`;

--- a/gui/src/locales/en.js
+++ b/gui/src/locales/en.js
@@ -158,7 +158,11 @@ export default {
                           <p>TCP: {tcpPorts}</p>
                           <p>UDP: {udpPorts}</p>`,
       xtlsNotWithWs: `xtls cannot work with websocket`,
-      grpcShouldWithTls: `gRPC must be with TLS`
+      grpcShouldWithTls: `gRPC must be with TLS`,
+      ssPluginImpl:
+        "★default: 'transport' for simple-obfs, 'chained' for v2ray-plugin." +
+        "★chained: shadowsocks traffic will be redirect to standalone plugin." +
+        "★transport: processed by the transport layer of v2ray/xray core directly."
     }
   },
   customAddressPort: {

--- a/gui/src/locales/zh.js
+++ b/gui/src/locales/zh.js
@@ -157,7 +157,11 @@ export default {
                           <p>TCP: {tcpPorts}</p>
                           <p>UDP: {udpPorts}</p>`,
       xtlsNotWithWs: `xtls无法和websocket共存`,
-      grpcShouldWithTls: `gRPC必须启用TLS`
+      grpcShouldWithTls: `gRPC必须启用TLS`,
+      ssPluginImpl:
+        "★默认：使用 simple-obfs 时为等效传输层，v2ray-plugin 时为链式。" +
+        "★链式：shadowsocks 流量会被转发至独立的插件。" +
+        "★等效传输层：直接由 v2ray/xray 核心的传输层处理。"
     }
   },
   customAddressPort: {


### PR DESCRIPTION
我使用的一家机场订阅遇到了和 #597 类似的情况（aes-256-gcm+simple-obfs 无法上网），但Windows 上使用最新的v2rayN 可以。我参照 v2rayN 对 obfs 的处理方式，实现了一套新的 shadowsocks plugin 处理逻辑（直接转换为相应的传输层设置）

- simple-obfs ：http 模式已通过验证
- v2ray-plugin：websocket 模式已通过验证

我已在 UI 引入了切换开关，但在处理后端切换逻辑时遇到了点问题。直接在 https://github.com/v2rayA/v2rayA/blob/288cd62a104c15d19f7e5b8f28e3cd6859da33fc/service/core/serverObj/shadowsocks.go 文件内 `import github.com/v2rayA/v2rayA/db/configure` 会导致循环导入。

@mzz2017 请教一下，有没有比较好的解决方法