### PR TITLE
Fixed for Docker Compose (ArchLinux)

### DIFF
--- a/service/core/iptables/tproxy.go
+++ b/service/core/iptables/tproxy.go
@@ -16,7 +16,7 @@ var Tproxy tproxy
 func (t *tproxy) AddIPWhitelist(cidr string) {
 	// avoid duplication
 	t.RemoveIPWhitelist(cidr)
-	pos := 5
+	pos := 6
 	if configure.GetSettingNotNil().AntiPollution != configure.AntipollutionClosed {
 		pos += 3
 	}
@@ -65,7 +65,7 @@ iptables -w 2 -t mangle -A TP_PRE -p udp -m mark --mark 0x40/0xc0 -j TPROXY --on
 
 iptables -w 2 -t mangle -A TP_RULE -j CONNMARK --restore-mark
 iptables -w 2 -t mangle -A TP_RULE -m mark --mark 0x40/0xc0 -j RETURN
-iptables -w 2 -t mangle -A TP_RULE -i br+ -j RETURN
+iptables -w 2 -t mangle -A TP_RULE -i br-+ -j RETURN
 iptables -w 2 -t mangle -A TP_RULE -i docker+ -j RETURN
 iptables -w 2 -t mangle -A TP_RULE -i veth+ -j RETURN
 `
@@ -124,7 +124,7 @@ ip6tables -w 2 -t mangle -A TP_PRE -p udp -m mark --mark 0x40/0xc0 -j TPROXY --o
 
 ip6tables -w 2 -t mangle -A TP_RULE -j CONNMARK --restore-mark
 ip6tables -w 2 -t mangle -A TP_RULE -m mark --mark 0x40/0xc0 -j RETURN
-ip6tables -w 2 -t mangle -A TP_RULE -i br+ -j RETURN
+ip6tables -w 2 -t mangle -A TP_RULE -i br-+ -j RETURN
 ip6tables -w 2 -t mangle -A TP_RULE -i docker+ -j RETURN
 ip6tables -w 2 -t mangle -A TP_RULE -i veth+ -j RETURN
 `

--- a/service/core/iptables/tproxy.go
+++ b/service/core/iptables/tproxy.go
@@ -124,7 +124,6 @@ ip6tables -w 2 -t mangle -A TP_PRE -p udp -m mark --mark 0x40/0xc0 -j TPROXY --o
 
 ip6tables -w 2 -t mangle -A TP_RULE -j CONNMARK --restore-mark
 ip6tables -w 2 -t mangle -A TP_RULE -m mark --mark 0x40/0xc0 -j RETURN
-ip6tables -w 2 -t mangle -A TP_RULE -m mark --mark 0x40/0xc0 -j RETURN
 ip6tables -w 2 -t mangle -A TP_RULE -i br+ -j RETURN
 ip6tables -w 2 -t mangle -A TP_RULE -i docker+ -j RETURN
 ip6tables -w 2 -t mangle -A TP_RULE -i veth+ -j RETURN
@@ -159,7 +158,7 @@ ip6tables -w 2 -t mangle -A TP_MARK -j CONNMARK --save-mark
 
 func (t *tproxy) GetCleanCommands() Setter {
 	commands := `
-ip rule del fwmark 0x40/0xc0 table 100
+ip rule del fwmark 0x40/0xc0 table 100 
 ip route del local 0.0.0.0/0 dev lo table 100
 
 iptables -w 2 -t mangle -F TP_OUT
@@ -175,7 +174,7 @@ iptables -w 2 -t mangle -X TP_MARK
 `
 	if IsIPv6Supported() {
 		commands += `
-ip -6 rule del fwmark 0x40/0xc0 table 100
+ip -6 rule del fwmark 0x40/0xc0 table 100 
 ip -6 route del local ::/0 dev lo table 100
 
 ip6tables -w 2 -t mangle -F TP_OUT

--- a/service/core/iptables/tproxy.go
+++ b/service/core/iptables/tproxy.go
@@ -65,6 +65,7 @@ iptables -w 2 -t mangle -A TP_PRE -p udp -m mark --mark 0x40/0xc0 -j TPROXY --on
 
 iptables -w 2 -t mangle -A TP_RULE -j CONNMARK --restore-mark
 iptables -w 2 -t mangle -A TP_RULE -m mark --mark 0x40/0xc0 -j RETURN
+iptables -w 2 -t mangle -A TP_RULE -i br+ -j RETURN
 iptables -w 2 -t mangle -A TP_RULE -i docker+ -j RETURN
 iptables -w 2 -t mangle -A TP_RULE -i veth+ -j RETURN
 `
@@ -123,6 +124,8 @@ ip6tables -w 2 -t mangle -A TP_PRE -p udp -m mark --mark 0x40/0xc0 -j TPROXY --o
 
 ip6tables -w 2 -t mangle -A TP_RULE -j CONNMARK --restore-mark
 ip6tables -w 2 -t mangle -A TP_RULE -m mark --mark 0x40/0xc0 -j RETURN
+ip6tables -w 2 -t mangle -A TP_RULE -m mark --mark 0x40/0xc0 -j RETURN
+ip6tables -w 2 -t mangle -A TP_RULE -i br+ -j RETURN
 ip6tables -w 2 -t mangle -A TP_RULE -i docker+ -j RETURN
 ip6tables -w 2 -t mangle -A TP_RULE -i veth+ -j RETURN
 `
@@ -156,7 +159,7 @@ ip6tables -w 2 -t mangle -A TP_MARK -j CONNMARK --save-mark
 
 func (t *tproxy) GetCleanCommands() Setter {
 	commands := `
-ip rule del fwmark 0x40/0xc0 table 100 
+ip rule del fwmark 0x40/0xc0 table 100
 ip route del local 0.0.0.0/0 dev lo table 100
 
 iptables -w 2 -t mangle -F TP_OUT
@@ -172,7 +175,7 @@ iptables -w 2 -t mangle -X TP_MARK
 `
 	if IsIPv6Supported() {
 		commands += `
-ip -6 rule del fwmark 0x40/0xc0 table 100 
+ip -6 rule del fwmark 0x40/0xc0 table 100
 ip -6 route del local ::/0 dev lo table 100
 
 ip6tables -w 2 -t mangle -F TP_OUT


### PR DESCRIPTION
According to the [document](https://v2raya.org/docs/advanced-application/specify-container-proxy/#%E9%80%8F%E6%98%8E%E4%BB%A3%E7%90%86%E4%BD%BF%E7%94%A8-tproxy-%E6%A8%A1%E5%BC%8F), all bridged containers should access the internet directly.

However, on my Arch Linux with Docker 20.10.17 and Docker Compose 2.9.0, the default (compose) network creates a bridge interface with name like `br-xxx:`. Therefore, we should early return in the `TP_RULE` to prevent the corresponding traffic to be marked.