### PR TITLE
chore(config): add default env config file for systemd user

### DIFF
--- a/install/aur/v2raya-bin/.SRCINFO
+++ b/install/aur/v2raya-bin/.SRCINFO
@@ -10,11 +10,9 @@ pkgbase = v2raya-bin
 	arch = armv6h
 	arch = aarch64
 	license = AGPL3
-	depends = glibc
-	optdepends = v2ray>=4.37.0-1
-	optdepends = xray>=1.4.2-1
 	provides = v2raya
 	conflicts = v2raya
+	backup = etc/default/v2raya
 	source = v2raya.service
 	source = v2raya-lite.service
 	source = v2raya.png
@@ -23,16 +21,16 @@ pkgbase = v2raya-bin
 	sha1sums = {{sha_service_lite}}
 	sha1sums = {{sha_png}}
 	sha1sums = {{sha_desktop}}
-	source_i686 = v2raya::https://apt.v2raya.org/static/v2raya_linux_x86_{{pkgver}}
+	source_i686 = v2raya_{{pkgver}}::https://apt.v2raya.org/static/v2raya_linux_x86_{{pkgver}}
 	sha1sums_i686 = {{sha1sums_i686}}
-	source_x86_64 = v2raya::https://apt.v2raya.org/static/v2raya_linux_x64_{{pkgver}}
+	source_x86_64 = v2raya_{{pkgver}}::https://apt.v2raya.org/static/v2raya_linux_x64_{{pkgver}}
 	sha1sums_x86_64 = {{sha1sums_x86_64}}
-	source_armv7h = v2raya::https://apt.v2raya.org/static/v2raya_linux_arm_{{pkgver}}
+	source_armv7h = v2raya_{{pkgver}}::https://apt.v2raya.org/static/v2raya_linux_arm_{{pkgver}}
 	sha1sums_armv7h = {{sha1sums_armv7h}}
-	source_armv6h = v2raya::https://apt.v2raya.org/static/v2raya_linux_arm_{{pkgver}}
+	source_armv6h = v2raya_{{pkgver}}::https://apt.v2raya.org/static/v2raya_linux_arm_{{pkgver}}
 	sha1sums_armv6h = {{sha1sums_armv6h}}
-	source_aarch64 = v2raya::https://apt.v2raya.org/static/v2raya_linux_arm64_{{pkgver}}
+	source_aarch64 = v2raya_{{pkgver}}::https://apt.v2raya.org/static/v2raya_linux_arm64_{{pkgver}}
 	sha1sums_aarch64 = {{sha1sums_aarch64}}
 
 pkgname = v2raya-bin
-	depends = glibc
+	depends = v2ray>=5.0.0

--- a/install/aur/v2raya-bin/PKGBUILD
+++ b/install/aur/v2raya-bin/PKGBUILD
@@ -11,6 +11,7 @@ url="https://github.com/v2rayA/v2rayA"
 license=('AGPL3')
 provides=('v2raya')
 conflicts=('v2raya')
+backup=("etc/default/v2raya")
 
 sha_service={{sha_service}}
 sha_service_lite={{sha_service_lite}}
@@ -63,6 +64,19 @@ sha1sums_armv7h=(
     '{{sha1sums_armv7h}}'
 )
 
+build() {
+    cd "$srcdir"
+
+    # generate default config
+    cat > "$srcdir/v2raya.conf" << EOF
+# v2raya config example
+# Everything has defaults so you only need to uncomment things you want to
+# change
+
+EOF
+    ./v2raya_"${pkgver}" --report config | sed '1,6d' | fold -s -w 78 | sed -E 's/^([^#].+)/# \1/'  >> "$srcdir/v2raya.conf"
+}
+
 package() {
     depends+=('v2ray>=5.0.0')
 
@@ -72,4 +86,5 @@ package() {
     install -Dm 644 v2raya.service -t "${pkgdir}"/usr/lib/systemd/system/
     install -Dm 644 v2raya-lite.service -t "${pkgdir}"/usr/lib/systemd/user/
     install -Dm 644 v2raya.png "${pkgdir}"/usr/share/icons/hicolor/512x512/apps/v2raya.png
+    install -Dm 644 v2raya.conf "${pkgdir}"/etc/default/v2raya
 }

--- a/install/aur/v2raya/.SRCINFO
+++ b/install/aur/v2raya/.SRCINFO
@@ -16,10 +16,11 @@ pkgbase = v2raya
 	makedepends = go>=2:1.17.0-1
 	makedepends = nodejs>=14
 	makedepends = yarn
-    depends = glibc
+	depends = glibc
+	backup = etc/default/v2raya
 	source = v2raya-{{pkgver}}.tar.gz::https://github.com/v2rayA/v2rayA/archive/v{{pkgver}}.tar.gz
 	sha512sums = SKIP
 
 pkgname = v2raya
-    depends = glibc
-    depends = v2ray>=5.0.0
+	depends = glibc
+	depends = v2ray>=5.0.0

--- a/install/aur/v2raya/PKGBUILD
+++ b/install/aur/v2raya/PKGBUILD
@@ -12,6 +12,7 @@ depends=('glibc')
 makedepends=('git' 'go>=2:1.17.0-1' 'nodejs>=14' 'yarn')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/v2rayA/v2rayA/archive/v$pkgver.tar.gz")
 sha512sums=('SKIP')
+backup=("etc/default/v2raya")
 
 build() {
     cd "$srcdir/v2rayA-$pkgver/gui"
@@ -22,6 +23,15 @@ build() {
     export GO111MODULE=on
     export GOPROXY=https://mirrors.aliyun.com/goproxy/,direct
     go build -ldflags '-X github.com/v2rayA/v2rayA/conf.Version='$pkgver' -s -w' -o v2raya
+    
+    # generate default config
+    cat > "$srcdir/v2rayA-$pkgver/v2raya.conf" << EOF
+# v2raya config example
+# Everything has defaults so you only need to uncomment things you want to
+# change
+
+EOF
+    ./v2raya --report config | sed '1,6d' | fold -s -w 78 | sed -E 's/^([^#].+)/# \1/'  >> "$srcdir/v2rayA-$pkgver/v2raya.conf"
 }
 
 package() {
@@ -34,4 +44,5 @@ package() {
     install -Dm 644 install/universal/v2raya.service -t "${pkgdir}"/usr/lib/systemd/system/
     install -Dm 644 install/universal/v2raya-lite.service -t "${pkgdir}"/usr/lib/systemd/user/
     install -Dm 644 gui/public/img/icons/android-chrome-512x512.png "${pkgdir}"/usr/share/icons/hicolor/512x512/apps/v2raya.png
+    install -Dm 644 v2raya.conf "${pkgdir}"/etc/default/v2raya
 }

--- a/install/universal/v2raya.service
+++ b/install/universal/v2raya.service
@@ -11,6 +11,7 @@ LimitNPROC=500
 LimitNOFILE=1000000
 ExecStart=/usr/bin/v2raya --log-disable-timestamp
 Environment=V2RAYA_LOG_FILE=/var/log/v2raya/v2raya.log
+EnvironmentFile=-/etc/default/v2raya
 Restart=on-failure
 
 [Install]

--- a/service/conf/environmentConfig.go
+++ b/service/conf/environmentConfig.go
@@ -2,14 +2,15 @@ package conf
 
 import (
 	"fmt"
-	"github.com/stevenroose/gonfig"
-	"github.com/v2rayA/v2rayA/common"
-	"github.com/v2rayA/v2rayA/pkg/util/log"
 	log2 "log"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/stevenroose/gonfig"
+	"github.com/v2rayA/v2rayA/common"
+	"github.com/v2rayA/v2rayA/pkg/util/log"
 )
 
 type Params struct {
@@ -23,16 +24,16 @@ type Params struct {
 	PluginManager        string `id:"plugin-manager" desc:"the executable file to run in the v2ray-core life-cycle. v2rayA will pass in the --stage (pre-start, post-start, pre-stop, post-stop) argument."`
 	WebDir               string `id:"webdir" desc:"v2rayA web files directory. use embedded files if not specify."`
 	IPV6Support          string `id:"ipv6-support" default:"auto" desc:"Optional values: auto, on, off. Make sure your IPv6 network works fine before you turn it on."`
-	PassCheckRoot        bool   `desc:"Skip privilege checking. Use it only when you cannot start v2raya but confirm you have root privilege"`
-	ResetPassword        bool   `id:"reset-password"`
+	PassCheckRoot        bool   `id:"pass-check-root" desc:"Skip privilege checking. Use it only when you cannot start v2raya but confirm you have root privilege"`
+	ResetPassword        bool   `id:"reset-password" ignore:"1"`
 	LogLevel             string `id:"log-level" default:"info" desc:"Optional values: trace, debug, info, warn or error"`
 	LogFile              string `id:"log-file" desc:"The path of log file"`
 	LogMaxDays           int64  `id:"log-max-days" default:"3" desc:"Maximum number of days to keep log files"`
-	LogDisableColor      bool   `id:"log-disable-color"`
-	LogDisableTimestamp  bool   `id:"log-disable-timestamp" desc:"Intended for use with systemd/journald to avoid duplicate timestamps in logs. This flag is ignored when using the --log-file flag or the V2RAYA_LOG_FILE environment variable."`
-	Lite                 bool   `id:"lite" desc:"Lite mode for non-root and non-linux users"`
-	ShowVersion          bool   `id:"version"`
-	PrintReport          string `id:"report" desc:"Print report"`
+	LogDisableColor      bool   `id:"log-disable-color" ignore:"1"`
+	LogDisableTimestamp  bool   `id:"log-disable-timestamp" desc:"Intended for use with systemd/journald to avoid duplicate timestamps in logs. This flag is ignored when using the --log-file flag or the V2RAYA_LOG_FILE environment variable." ignore:"1"`
+	Lite                 bool   `id:"lite" desc:"Lite mode for non-root and non-linux users" ignore:"1"`
+	ShowVersion          bool   `id:"version" ignore:"1"`
+	PrintReport          string `id:"report" desc:"Print report" ignore:"1"`
 }
 
 var params Params

--- a/service/conf/environmentConfig.go
+++ b/service/conf/environmentConfig.go
@@ -24,7 +24,7 @@ type Params struct {
 	PluginManager        string `id:"plugin-manager" desc:"the executable file to run in the v2ray-core life-cycle. v2rayA will pass in the --stage (pre-start, post-start, pre-stop, post-stop) argument."`
 	WebDir               string `id:"webdir" desc:"v2rayA web files directory. use embedded files if not specify."`
 	IPV6Support          string `id:"ipv6-support" default:"auto" desc:"Optional values: auto, on, off. Make sure your IPv6 network works fine before you turn it on."`
-	PassCheckRoot        bool   `id:"pass-check-root" desc:"Skip privilege checking. Use it only when you cannot start v2raya but confirm you have root privilege"`
+	PassCheckRoot        bool   `id:"passcheckroot" desc:"Skip privilege checking. Use it only when you cannot start v2raya but confirm you have root privilege"`
 	ResetPassword        bool   `id:"reset-password" ignore:"1"`
 	LogLevel             string `id:"log-level" default:"info" desc:"Optional values: trace, debug, info, warn or error"`
 	LogFile              string `id:"log-file" desc:"The path of log file"`

--- a/service/conf/report/config.go
+++ b/service/conf/report/config.go
@@ -1,0 +1,56 @@
+package report
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/v2rayA/v2rayA/conf"
+)
+
+func init() {
+	conf.RegisterReportType(
+		conf.ReportType{
+			Name: "config",
+			Desc: "print the Report of configs",
+			Func: ConfigReport,
+		},
+	)
+}
+
+// makeEnvKey creates the environment variable key with the opts fullId and
+// prefix by joining all parts together with underscores and putting all to
+// upper case.
+func makeEnvKey(prefix string, fullID []string) string {
+	key := strings.Join(fullID, "_")
+	key = strings.Replace(key, "-", "_", -1)
+	key = prefix + key
+	key = strings.ToUpper(key)
+	return key
+}
+
+func ConfigReport(arg []string) (report string) {
+
+	var lines []string
+	defer func() {
+		report = strings.Join(lines, "\n")
+	}()
+
+	t := reflect.ValueOf(conf.GetEnvironmentConfig()).Elem()
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Type().Field(i).Tag
+		if _, ok := tag.Lookup("ignore"); ok {
+			continue
+		}
+		id, ok := tag.Lookup("id")
+		if !ok {
+			continue
+		}
+		desc := tag.Get("desc")
+		envKey := makeEnvKey("V2RAYA_", []string{id})
+		value := t.Field(i).Interface()
+		lines = append(lines, fmt.Sprintf("# %v", desc))
+		lines = append(lines, fmt.Sprintf("%v=%v\n", envKey, value))
+	}
+	return
+}


### PR DESCRIPTION
- Add a cmd `v2raya --report config` to report current config.
- generate `/etc/default/v2raya` for systemd user as `EnvironmentFile`

```bash
./v2raya --report config | sed '1,6d' | fold -s -w 78 | sed -E 's/^([^#].+)/# \1/' 
```
 
