### PR TITLE
optimize: reduce disk writes

### DIFF
--- a/service/db/boltdb.go
+++ b/service/db/boltdb.go
@@ -1,13 +1,14 @@
 package db
 
 import (
-	"go.etcd.io/bbolt"
-	"github.com/v2rayA/v2rayA/conf"
-	"github.com/v2rayA/v2rayA/pkg/util/copyfile"
-	"github.com/v2rayA/v2rayA/pkg/util/log"
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/v2rayA/v2rayA/conf"
+	"github.com/v2rayA/v2rayA/pkg/util/copyfile"
+	"github.com/v2rayA/v2rayA/pkg/util/log"
+	"go.etcd.io/bbolt"
 )
 
 var once sync.Once
@@ -45,4 +46,38 @@ func initDB() {
 func DB() *bbolt.DB {
 	once.Do(initDB)
 	return db
+}
+
+// The function should return a dirty flag.
+// If the dirty flag is true and there is no error then the transaction is commited.
+// Otherwise, the transaction is rolled back.
+func Transaction(db *bbolt.DB, fn func(*bbolt.Tx) (bool, error)) error {
+	tx, err := db.Begin(true)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	dirty, err := fn(tx)
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if !dirty {
+		return nil
+	}
+	return tx.Commit()
+}
+
+// If the bucket does not exist, the dirty flag is setted
+func CreateBucketIfNotExists(tx *bbolt.Tx, name []byte, dirty *bool) (*bbolt.Bucket, error) {
+	bkt := tx.Bucket(name)
+	if bkt != nil {
+		return bkt, nil
+	}
+	bkt, err := tx.CreateBucket(name)
+	if err != nil {
+		return nil, err
+	}
+	*dirty = true
+	return bkt, nil
 }

--- a/service/db/boltdb.go
+++ b/service/db/boltdb.go
@@ -56,14 +56,13 @@ func Transaction(db *bbolt.DB, fn func(*bbolt.Tx) (bool, error)) error {
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback()
 	dirty, err := fn(tx)
 	if err != nil {
 		_ = tx.Rollback()
 		return err
 	}
 	if !dirty {
-		return nil
+		return tx.Rollback()
 	}
 	return tx.Commit()
 }

--- a/service/db/listOp.go
+++ b/service/db/listOp.go
@@ -2,13 +2,14 @@ package db
 
 import (
 	"fmt"
-	"go.etcd.io/bbolt"
-	jsoniter "github.com/json-iterator/go"
-	"github.com/tidwall/gjson"
-	"github.com/tidwall/sjson"
 	"reflect"
 	"sort"
 	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+	"go.etcd.io/bbolt"
 )
 
 func ListSet(bucket string, key string, index int, val interface{}) (err error) {
@@ -31,20 +32,21 @@ func ListSet(bucket string, key string, index int, val interface{}) (err error) 
 }
 
 func ListGet(bucket string, key string, index int) (b []byte, err error) {
-	err = DB().Update(func(tx *bbolt.Tx) error {
-		if bkt, err := tx.CreateBucketIfNotExists([]byte(bucket)); err != nil {
-			return err
+	err = Transaction(DB(), func(tx *bbolt.Tx) (bool, error) {
+		dirty := false
+		if bkt, err := CreateBucketIfNotExists(tx, []byte(bucket), &dirty); err != nil {
+			return dirty, err
 		} else {
 			v := bkt.Get([]byte(key))
 			if v == nil {
-				return fmt.Errorf("ListGet: can't get element from an empty list")
+				return dirty, fmt.Errorf("ListGet: can't get element from an empty list")
 			}
 			r := gjson.GetBytes(v, strconv.Itoa(index))
 			if r.Exists() {
 				b = []byte(r.Raw)
-				return nil
+				return dirty, nil
 			} else {
-				return fmt.Errorf("ListGet: no such element")
+				return dirty, fmt.Errorf("ListGet: no such element")
 			}
 		}
 	})
@@ -79,24 +81,25 @@ func ListAppend(bucket string, key string, val interface{}) (err error) {
 }
 
 func ListGetAll(bucket string, key string) (list [][]byte, err error) {
-	err = DB().Update(func(tx *bbolt.Tx) error {
-		if bkt, err := tx.CreateBucketIfNotExists([]byte(bucket)); err != nil {
-			return err
+	err = Transaction(DB(), func(tx *bbolt.Tx) (bool, error) {
+		dirty := false
+		if bkt, err := CreateBucketIfNotExists(tx, []byte(bucket), &dirty); err != nil {
+			return dirty, err
 		} else {
 			b := bkt.Get([]byte(key))
 			if b == nil {
-				return nil
+				return dirty, nil
 			}
 			parsed := gjson.ParseBytes(b)
 			if !parsed.IsArray() {
-				return fmt.Errorf("ListGetAll: is not array")
+				return dirty, fmt.Errorf("ListGetAll: is not array")
 			}
 			results := parsed.Array()
 			for _, r := range results {
 				list = append(list, []byte(r.Raw))
 			}
 		}
-		return nil
+		return dirty, nil
 	})
 	return list, err
 }
@@ -143,21 +146,22 @@ func ListRemove(bucket, key string, indexes []int) error {
 }
 
 func ListLen(bucket string, key string) (length int, err error) {
-	err = DB().Update(func(tx *bbolt.Tx) error {
-		if bkt, err := tx.CreateBucketIfNotExists([]byte(bucket)); err != nil {
-			return err
+	err = Transaction(DB(), func(tx *bbolt.Tx) (bool, error) {
+		dirty := false
+		if bkt, err := CreateBucketIfNotExists(tx, []byte(bucket), &dirty); err != nil {
+			return dirty, err
 		} else {
 			b := bkt.Get([]byte(key))
 			if b == nil {
-				return nil
+				return dirty, nil
 			}
 			parsed := gjson.ParseBytes(b)
 			if !parsed.IsArray() {
-				return fmt.Errorf("ListLen: is not array")
+				return dirty, fmt.Errorf("ListLen: is not array")
 			}
 			length = len(parsed.Array())
 		}
-		return nil
+		return dirty, nil
 	})
 	return length, err
 }

--- a/service/db/plainOp.go
+++ b/service/db/plainOp.go
@@ -2,50 +2,54 @@ package db
 
 import (
 	"fmt"
-	"go.etcd.io/bbolt"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/v2rayA/v2rayA/common"
 	"github.com/v2rayA/v2rayA/pkg/util/log"
+	"go.etcd.io/bbolt"
 )
 
 func Get(bucket string, key string, val interface{}) (err error) {
-	return DB().Update(func(tx *bbolt.Tx) error {
-		if bkt, err := tx.CreateBucketIfNotExists([]byte(bucket)); err != nil {
-			return err
+	return Transaction(DB(), func(tx *bbolt.Tx) (bool, error) {
+		dirty := false
+		if bkt, err := CreateBucketIfNotExists(tx, []byte(bucket), &dirty); err != nil {
+			return dirty, err
 		} else {
 			if v := bkt.Get([]byte(key)); v == nil {
-				return fmt.Errorf("Get: key is not found")
+				return dirty, fmt.Errorf("Get: key is not found")
 			} else {
-				return jsoniter.Unmarshal(v, val)
+				return dirty, jsoniter.Unmarshal(v, val)
 			}
 		}
 	})
 }
 
 func GetRaw(bucket string, key string) (b []byte, err error) {
-	err = DB().Update(func(tx *bbolt.Tx) error {
-		if bkt, err := tx.CreateBucketIfNotExists([]byte(bucket)); err != nil {
-			return err
+	err = Transaction(DB(), func(tx *bbolt.Tx) (bool, error) {
+		dirty := false
+		if bkt, err := CreateBucketIfNotExists(tx, []byte(bucket), &dirty); err != nil {
+			return dirty, err
 		} else {
 			v := bkt.Get([]byte(key))
 			if v == nil {
-				return fmt.Errorf("GetRaw: key is not found")
+				return dirty, fmt.Errorf("GetRaw: key is not found")
 			}
 			b = common.BytesCopy(v)
-			return nil
+			return dirty, nil
 		}
 	})
 	return b, err
 }
 
 func Exists(bucket string, key string) (exists bool) {
-	if err := DB().Update(func(tx *bbolt.Tx) error {
-		if bkt, err := tx.CreateBucketIfNotExists([]byte(bucket)); err != nil {
-			return err
+	if err := Transaction(DB(), func(tx *bbolt.Tx) (bool, error) {
+		dirty := false
+		if bkt, err := CreateBucketIfNotExists(tx, []byte(bucket), &dirty); err != nil {
+			return dirty, err
 		} else {
 			v := bkt.Get([]byte(key))
 			exists = v != nil
-			return nil
+			return dirty, nil
 		}
 	}); err != nil {
 		log.Warn("%v", err)
@@ -55,23 +59,25 @@ func Exists(bucket string, key string) (exists bool) {
 }
 
 func GetBucketLen(bucket string) (length int, err error) {
-	err = DB().Update(func(tx *bbolt.Tx) error {
-		if bkt, err := tx.CreateBucketIfNotExists([]byte(bucket)); err != nil {
-			return err
+	err = Transaction(DB(), func(tx *bbolt.Tx) (bool, error) {
+		dirty := false
+		if bkt, err := CreateBucketIfNotExists(tx, []byte(bucket), &dirty); err != nil {
+			return dirty, err
 		} else {
 			length = bkt.Stats().KeyN
 		}
-		return nil
+		return dirty, nil
 	})
 	return length, err
 }
 
 func GetBucketKeys(bucket string) (keys []string, err error) {
-	err = DB().Update(func(tx *bbolt.Tx) error {
-		if bkt, err := tx.CreateBucketIfNotExists([]byte(bucket)); err != nil {
-			return err
+	err = Transaction(DB(), func(tx *bbolt.Tx) (bool, error) {
+		dirty := false
+		if bkt, err := CreateBucketIfNotExists(tx, []byte(bucket), &dirty); err != nil {
+			return dirty, err
 		} else {
-			return bkt.ForEach(func(k, v []byte) error {
+			return dirty, bkt.ForEach(func(k, v []byte) error {
 				keys = append(keys, string(k))
 				return nil
 			})


### PR DESCRIPTION
Fix: #685 

As it mentioned in #685, disk writes are greatly reduced by using read-only transactions as much as possible.
