### PR TITLE
fix(subtime): remove timezone guess

### DIFF
--- a/gui/src/node.vue
+++ b/gui/src/node.vue
@@ -765,7 +765,6 @@ export default {
     tableData(x) {
       for (const sub of x.subscriptions) {
         sub.status = dayjs(sub.status)
-          .tz(dayjs.tz.guess())
           .format("YYYY-MM-DD HH:mm:ss");
       }
     },


### PR DESCRIPTION
remove tz.guess
In case the raw time format is in `YYYY-MM-DD HH:mm:ss`

-----------
![image](https://user-images.githubusercontent.com/32241529/202375904-47be3399-3ed3-41f3-9cb8-9e6bcbcc2567.png)