### PR TITLE
v2rayA should start after nftables

### DIFF
--- a/install/universal/v2raya-lite.service
+++ b/install/universal/v2raya-lite.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=v2rayA Lite Service
 Documentation=https://github.com/v2rayA/v2rayA/wiki
-After=network.target nss-lookup.target iptables.service ip6tables.service
+After=network.target nss-lookup.target iptables.service ip6tables.service nftables.service
 Wants=network.target
 
 [Service]

--- a/install/universal/v2raya.service
+++ b/install/universal/v2raya.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=v2rayA Service
 Documentation=https://github.com/v2rayA/v2rayA/wiki
-After=network.target nss-lookup.target iptables.service ip6tables.service
+After=network.target nss-lookup.target iptables.service ip6tables.service nftables.service
 Wants=network.target
 
 [Service]


### PR DESCRIPTION
v2rayA should start after nftables, or rules made by v2rayA might be cleanup by nft.