### PR TITLE
ci: update deprecated actions and commands

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -9,15 +9,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Prepare
         id: prep
         run: |
           TAG=$(echo $GITHUB_REF | cut -d / -f 3)
           IMAGE="mzz2017/v2raya"
-          echo ::set-output name=image::${IMAGE}
-          echo ::set-output name=tag::${TAG:1}
+          echo image=${IMAGE} >> $GITHUB_OUTPUT
+          echo tag=${TAG:1} >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/dockerimage_gui.yml
+++ b/.github/workflows/dockerimage_gui.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/dockerimage_nightly.yml
+++ b/.github/workflows/dockerimage_nightly.yml
@@ -8,15 +8,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Prepare
         id: prep
         run: |
           TAG=$(git log --pretty=format:"%ad" --date=format:%Y%m%d $(git show -s --format=%H) -1)
           IMAGE="mzz2017/v2raya-nightly"
-          echo ::set-output name=image::${IMAGE}
-          echo ::set-output name=tag::${TAG}
+          echo image=${IMAGE} >> $GITHUB_OUTPUT
+          echo tag=${TAG} >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/release_feat_v5.yml
+++ b/.github/workflows/release_feat_v5.yml
@@ -29,7 +29,7 @@ jobs:
       DESC: "A web GUI client of Project V which supports VMess, VLESS, SS, SSR, Trojan and Pingtunnel protocols."
     steps:
     
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -51,16 +51,16 @@ jobs:
         echo "VERSION=$version" >> $GITHUB_OUTPUT
         echo "VERSION=$version" >> $GITHUB_ENV
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ^1.17
     - name: Set up Node.js
-      uses: actions/setup-node@v2.4.0
+      uses: actions/setup-node@v3
       with:
         node-version: lts/*
         cache: 'yarn'
         cache-dependency-path: gui/yarn.lock
-    - uses: ruby/setup-ruby@477b21f02be01bcb8030d50f37cfec92bfa615b6
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
         bundler-cache: true


### PR DESCRIPTION
ref https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ and https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/