### PR TITLE
build the docker images with nftables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN export VERSION=$(cat ./version) && CGO_ENABLED=0 go build -ldflags="-X githu
 FROM v2fly/v2fly-core
 COPY --from=builder /build/service/v2raya /usr/bin/
 RUN wget -O /usr/local/share/v2ray/LoyalsoldierSite.dat https://raw.githubusercontent.com/mzz2017/dist-v2ray-rules-dat/master/geosite.dat
-RUN apk add --no-cache iptables ip6tables nftables
+RUN apk add --no-cache iptables ip6tables nftables tzdata
 EXPOSE 2017
 VOLUME /etc/v2raya
 ENTRYPOINT ["v2raya"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN export VERSION=$(cat ./version) && CGO_ENABLED=0 go build -ldflags="-X githu
 FROM v2fly/v2fly-core
 COPY --from=builder /build/service/v2raya /usr/bin/
 RUN wget -O /usr/local/share/v2ray/LoyalsoldierSite.dat https://raw.githubusercontent.com/mzz2017/dist-v2ray-rules-dat/master/geosite.dat
-RUN apk add --no-cache iptables ip6tables
+RUN apk add --no-cache iptables ip6tables nftables
 EXPOSE 2017
 VOLUME /etc/v2raya
 ENTRYPOINT ["v2raya"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM v2fly/v2fly-core AS v2ray
 RUN ls /usr/local/share/v2ray || (mkdir -p /usr/local/share/v2ray && touch /usr/local/share/v2ray/.copykeep)
 
 FROM golang:alpine
-RUN apk --no-cache add iptables ip6tables nftables git
+RUN apk --no-cache add iptables ip6tables nftables tzdata git
 ENV GO111MODULE=on
 ENV GOPROXY=https://goproxy.cn
 RUN go get github.com/codegangsta/gin

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM v2fly/v2fly-core AS v2ray
 RUN ls /usr/local/share/v2ray || (mkdir -p /usr/local/share/v2ray && touch /usr/local/share/v2ray/.copykeep)
 
 FROM golang:alpine
-RUN apk --no-cache add iptables ip6tables git
+RUN apk --no-cache add iptables ip6tables nftables git
 ENV GO111MODULE=on
 ENV GOPROXY=https://goproxy.cn
 RUN go get github.com/codegangsta/gin

--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -25,7 +25,7 @@ RUN export VERSION=$(cat ./version) && CGO_ENABLED=0 go build -ldflags="-X githu
 FROM v2fly/v2fly-core
 COPY --from=builder /build/service/v2raya /usr/bin/
 RUN wget -O /usr/local/share/v2ray/LoyalsoldierSite.dat https://raw.githubusercontent.com/mzz2017/dist-v2ray-rules-dat/master/geosite.dat
-RUN apk add --no-cache iptables ip6tables
+RUN apk add --no-cache iptables ip6tables nftables
 EXPOSE 2017
 VOLUME /etc/v2raya
 ENTRYPOINT ["v2raya"]

--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -25,7 +25,7 @@ RUN export VERSION=$(cat ./version) && CGO_ENABLED=0 go build -ldflags="-X githu
 FROM v2fly/v2fly-core
 COPY --from=builder /build/service/v2raya /usr/bin/
 RUN wget -O /usr/local/share/v2ray/LoyalsoldierSite.dat https://raw.githubusercontent.com/mzz2017/dist-v2ray-rules-dat/master/geosite.dat
-RUN apk add --no-cache iptables ip6tables nftables
+RUN apk add --no-cache iptables ip6tables nftables tzdata
 EXPOSE 2017
 VOLUME /etc/v2raya
 ENTRYPOINT ["v2raya"]


### PR DESCRIPTION
nft support was introduced with [v2.0.4](https://github.com/v2rayA/v2rayA/releases/tag/v2.0.4), this adds `nftables` package as a dependency to the docker images.