### PR TITLE
Allow using flow option with TLS.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -ex
- CurrentDir="$(pwd)"
+CurrentDir="$(pwd)"
 
 if [ -d "$CurrentDir/.git" ]; then
   date=$(git -C "$CurrentDir" log -1 --format="%cd" --date=short | sed s/-//g)
@@ -14,8 +14,7 @@ fi
 # https://github.com/webpack/webpack/issues/14532#issuecomment-947012063
 export NODE_OPTIONS=--openssl-legacy-provider
 cd "$CurrentDir"/gui && yarn && OUTPUT_DIR="$CurrentDir"/service/server/router/web yarn build
-for file in $(find  "$CurrentDir"/service/server/router/web |grep -v png |grep -v index.html|grep -v .gz)
-do
+for file in $(find "$CurrentDir"/service/server/router/web | grep -v png | grep -v index.html | grep -v .gz); do
   if [ ! -d $file ];then
     gzip -9 $file
   fi

--- a/gui/src/components/modalServer.vue
+++ b/gui/src/components/modalServer.vue
@@ -98,6 +98,15 @@
               <option value="tls">tls</option>
             </b-select>
           </b-field>
+          <b-field v-show="v2ray.tls !== 'none'">
+            <b-input
+              ref="v2ray_flow"
+              v-model="v2ray.flow"
+              required
+              placeholder=""
+              expanded
+            />
+          </b-field>
           <b-field v-show="v2ray.tls !== 'none'" label-position="on-border">
             <template slot="label">
               AllowInsecure
@@ -791,6 +800,7 @@ export default {
       host: "",
       path: "",
       tls: "none",
+      flow: "",
       alpn: "",
       scy: "auto",
       v: "",
@@ -857,13 +867,6 @@ export default {
     },
     tabChoice: 0,
   }),
-  computed: {
-    filteredDataArray() {
-      return this.presetFlows.filter((option) => {
-        return option.toString().indexOf(this.v2ray.flow) >= 0;
-      });
-    },
-  },
   mounted() {
     if (this.which !== null) {
       this.$axios({
@@ -957,6 +960,7 @@ export default {
           path: u.params.path || u.params.serviceName || "",
           alpn: u.params.alpn || "",
           tls: u.params.security || "none",
+          flow: u.params.flow || "",
           allowInsecure: u.params.allowInsecure || false,
           protocol: "vless",
         };


### PR DESCRIPTION
Currently, the upstream xray project allows users to configure flow (e.g. xtls-rprx-vision) when using TLS, while v2raya lacks support for this. Please merge this PR to enhance the relevant functionality.

## Example
```json
{
    "protocol": "vless",
    "settings": {
        "vnext": [
            {
                "address": "<hostname>",
                "port": 443,
                "users": [
                    {
                        "id": "<client id>",
                        "encryption": "none",
                        "flow": "xtls-rprx-vision"
                    }
                ]
            }
        ]
    },
    "streamSettings": {
        "network": "tcp",
        "security": "tls"
    },
    "tag": "proxy"
}
```