### PR TITLE
fix a bug in /build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,9 +13,5 @@ else
 fi
 # https://github.com/webpack/webpack/issues/14532#issuecomment-947012063
 cd "$CurrentDir"/gui && yarn && OUTPUT_DIR="$CurrentDir"/service/server/router/web yarn build
-for file in $(find "$CurrentDir"/service/server/router/web | grep -v png | grep -v index.html | grep -v .gz); do
-  if [ ! -d $file ];then
-    gzip -9 $file
-  fi
-done
+find "$CurrentDir"/service/server/router/web \! -name \*.png -a \! -name \*.gz -a \! -name index.html -a ! -type d -exec gzip -9 {} +
 cd "$CurrentDir"/service && CGO_ENABLED=0 go build -ldflags "-X github.com/v2rayA/v2rayA/conf.Version=$version -s -w" -o "$CurrentDir"/v2raya


### PR DESCRIPTION
If the value of $CurrentDir contains whitespaces, $file in `for` loop could get non-existing file paths, which in turn fails the building process.

This commit fixes that bug by discarding the entire `for` loop and running solely the `find` command with the `gzip` commanded in the `-exec` clause after file paths filtered by `-name` and `-type` predicates.