### PR TITLE
Improve server list table columns

### DIFF
--- a/gui/src/node.vue
+++ b/gui/src/node.vue
@@ -336,7 +336,11 @@
                 :label="$t('server.address')"
                 sortable
               >
-                {{ props.row.address }}
+                <p 
+                  class="address-column" 
+                  :title="props.row.address">
+                  {{ props.row.address }}
+                </p>
               </b-table-column>
               <b-table-column
                 v-slot="props"
@@ -354,7 +358,13 @@
                 sortable
                 :custom-sort="sortping"
               >
-                {{ props.row.pingLatency }}
+                <p 
+                  :class="{
+                      'latency-column': true,
+                    }" 
+                  :title="props.row.pingLatency">
+                  {{ props.row.pingLatency }}
+                </p>
               </b-table-column>
               <b-table-column
                 v-slot="props"
@@ -466,7 +476,11 @@
                 :label="$t('server.address')"
                 sortable
               >
-                {{ props.row.address }}
+                <p 
+                  class="address-column" 
+                  :title="props.row.address">
+                  {{ props.row.address }}
+                </p>
               </b-table-column>
               <b-table-column
                 v-slot="props"
@@ -485,7 +499,13 @@
                 sortable
                 :custom-sort="sortping"
               >
-                {{ props.row.pingLatency }}
+                <p 
+                   :class="{
+                      'latency-column': true,
+                    }" 
+                  :title="props.row.pingLatency">
+                  {{ props.row.pingLatency }}
+                </p>
               </b-table-column>
               <b-table-column
                 v-slot="props"
@@ -1777,5 +1797,25 @@ tr.highlight-row-disconnected {
 
 .click-through {
   pointer-events: none;
+}
+.address-column {
+  max-width: 350px!important;
+  overflow: hidden!important;
+  text-overflow: ellipsis!important;
+}
+.latency-column {
+  max-width: 120px!important;
+  overflow: hidden!important;
+  text-overflow: ellipsis!important;
+  white-space: nowrap;
+}
+
+@media screen and (max-width: 1920px) {
+  .latency-column {
+    max-width: 70px!important;
+  }
+  .address-column {
+    max-width: 150px!important;
+  }
 }
 </style>

--- a/gui/src/node.vue
+++ b/gui/src/node.vue
@@ -361,6 +361,7 @@
                 <p 
                   :class="{
                       'latency-column': true,
+                      'latency-valid': props.row.pingLatency.endsWith('ms')
                     }" 
                   :title="props.row.pingLatency">
                   {{ props.row.pingLatency }}
@@ -502,6 +503,7 @@
                 <p 
                    :class="{
                       'latency-column': true,
+                      'latency-valid': props.row.pingLatency.endsWith('ms')
                     }" 
                   :title="props.row.pingLatency">
                   {{ props.row.pingLatency }}
@@ -1808,6 +1810,9 @@ tr.highlight-row-disconnected {
   overflow: hidden!important;
   text-overflow: ellipsis!important;
   white-space: nowrap;
+}
+.latency-valid {
+  color: green;
 }
 
 @media screen and (max-width: 1920px) {


### PR DESCRIPTION
Set width for server address and server latency columns.
Colorize latency column.

the server address column max-width is set to 350 for full HD screens and larger sizes and 150px for smaller sizes.
if the server latency starts with a number it gets green and red otherwise.