### PR TITLE
fix: remove default GunService due to no mentioned

### DIFF
--- a/service/core/serverObj/v2ray.go
+++ b/service/core/serverObj/v2ray.go
@@ -274,9 +274,6 @@ func (v *V2Ray) Configuration(info PriorInfo) (c Configuration, err error) {
 		//TODO: QUIC
 		switch strings.ToLower(v.Net) {
 		case "grpc":
-			if v.Path == "" {
-				v.Path = "GunService"
-			}
 			core.StreamSettings.GrpcSettings = &coreObj.GrpcSettings{ServiceName: v.Path}
 		case "ws":
 			core.StreamSettings.WsSettings = &coreObj.WsSettings{


### PR DESCRIPTION
# Background

`GunService` is not mentioned in any of xray/v2ray documents as a default value, so we removed it.

Closes #1247
