### PR TITLE
Fix: Unexpected exiting when testing http latency of IPv6 only domains

### DIFF
--- a/service/core/iptables/utils.go
+++ b/service/core/iptables/utils.go
@@ -52,6 +52,8 @@ func IsIPv6Supported() bool {
 	}
 	if !nettest.SupportsIPv6() {
 		return false
+	} else if runtime.GOOS != "linux" {
+		return true
 	}
 	if IsNft() {
 		return true

--- a/service/server/service/latency.go
+++ b/service/server/service/latency.go
@@ -80,6 +80,9 @@ func addHosts(tmpl *v2ray.Template, vms []serverObj.ServerObj) {
 				}
 				if len(ips) > 0 {
 					ips = v2ray.FilterIPs(ips)
+					if len(ips) == 0 {
+						return
+					}
 					mu.Lock()
 					tmpl.DNS.Hosts[addr] = ips
 					mu.Unlock()


### PR DESCRIPTION
This issue https://github.com/v2rayA/v2rayA/issues/623 highlights an unexpected exiting problem when conducting http latency tests on IPv6-only domains. This issue persists in V2rayA 2.2.4.7 with V2Ray 5.12.1 (current latest version) on Windows 11 23H2. The log when the problem occurs is as follows:

```plaintext
2024/02/24 19:39:05.663 [I] [io.go:431]  panic: runtime error: invalid memory address or nil pointer dereference
2024/02/24 19:39:05.663 [I] [io.go:431]  [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6080d6b15f02]
2024/02/24 19:39:05.663 [I] [io.go:431]  
2024/02/24 19:39:05.663 [I] [io.go:431]  goroutine 1 [running]:
2024/02/24 19:39:05.663 [I] [io.go:431]  github.com/v2fly/v2ray-core/v5/infra/conf/synthetic/dns.getHostMapping(0x0)
2024/02/24 19:39:05.663 [I] [io.go:431]         github.com/v2fly/v2ray-core/v5/infra/conf/synthetic/dns/dns.go:243 +0x22
2024/02/24 19:39:05.663 [I] [io.go:431]  github.com/v2fly/v2ray-core/v5/infra/conf/synthetic/dns.(*DNSConfig).Build(0xc00012a960)
2024/02/24 19:39:05.663 [I] [io.go:431]         github.com/v2fly/v2ray-core/v5/infra/conf/synthetic/dns/dns.go:443 +0x154d
2024/02/24 19:39:05.663 [I] [io.go:431]  github.com/v2fly/v2ray-core/v5/infra/conf/v4.(*Config).Build(0xc0002300f0)
2024/02/24 19:39:05.663 [I] [io.go:431]         github.com/v2fly/v2ray-core/v5/infra/conf/v4/v2ray.go:426 +0x671
2024/02/24 19:39:05.663 [I] [io.go:431]  github.com/v2fly/v2ray-core/v5/main/formats.makeMergeLoader.makeLoaderFunc.func1({0x6080d6e496e0, 0xc000123a00})
2024/02/24 19:39:05.663 [I] [io.go:431]         github.com/v2fly/v2ray-core/v5/main/formats/formats.go:54 +0x92
2024/02/24 19:39:05.663 [I] [io.go:431]  github.com/v2fly/v2ray-core/v5.loadSingleConfigAutoFormatFromFile({0x7ffc05e70d82, 0x26})
2024/02/24 19:39:05.663 [I] [io.go:431]         github.com/v2fly/v2ray-core/v5/config.go:159 +0x16e
2024/02/24 19:39:05.663 [I] [io.go:431]  github.com/v2fly/v2ray-core/v5.loadSingleConfigAutoFormat({0x6080d6e67980?, 0xc000013a40?})
2024/02/24 19:39:05.663 [I] [io.go:431]         github.com/v2fly/v2ray-core/v5/config.go:140 +0xa5
2024/02/24 19:39:05.663 [I] [io.go:431]  github.com/v2fly/v2ray-core/v5.LoadConfig({0x6080d6b4b431, 0x4}, {0x6080d6e67980, 0xc000013a40})
2024/02/24 19:39:05.663 [I] [io.go:431]         github.com/v2fly/v2ray-core/v5/config.go:110 +0x125
2024/02/24 19:39:05.663 [I] [io.go:431]  github.com/v2fly/v2ray-core/v5/main/commands.startV2Ray()
2024/02/24 19:39:05.663 [I] [io.go:431]         github.com/v2fly/v2ray-core/v5/main/commands/run.go:194 +0x4c
2024/02/24 19:39:05.663 [I] [io.go:431]  github.com/v2fly/v2ray-core/v5/main/commands.executeRun(
2024/02/24 19:39:05.663 [I] [io.go:431]  0x6080d7b2c780, {0xc000040890, 0x1, 0x1})
2024/02/24 19:39:05.663 [I] [io.go:431]         github.com/v2fly/v2ray-core/v5/main/commands/run.go:81 +0xc5
2024/02/24 19:39:05.663 [I] [io.go:431]  github.com/v2fly/v2ray-core/v5/main/commands/base.Execute()
2024/02/24 19:39:05.663 [I] [io.go:431]         github.com/v2fly/v2ray-core/v5/main/commands/base/execute.go:67 +0x63d
2024/02/24 19:39:05.663 [I] [io.go:431]  main.main()
2024/02/24 19:39:05.663 [I] [io.go:431]         github.com/v2fly/v2ray-core/v5/main/main.go:16 +0x285
```

This is because the `FilterIps` function in `service/core/v2ray/v2rayTmpl.go` called by `addHosts` 

https://github.com/v2rayA/v2rayA/blob/df74d3cf12ade4abc2cfbc8be6ac58898254ce4e/service/server/service/latency.go#L81-L86

https://github.com/v2rayA/v2rayA/blob/df74d3cf12ade4abc2cfbc8be6ac58898254ce4e/service/core/v2ray/v2rayTmpl.go#L389-L408

returns an empty array when the system does not support IPv6 and the domain has only IPv6 resolution values.

This empty array is eventually parsed into the V2Ray configuration file `config.json` as 
```json
    "dns": {
        "hosts": {
            "<IPv6 domain>": null
        },
        "servers": null
    },
```
causing a nil pointer dereference in V2Ray core when paring the hosts.

To fix this, I added an additional check for empty return value of `FilterIps`:
```go
if len(ips) > 0 {
    ips = v2ray.FilterIPs(ips)
    if len(ips) == 0 {
        return
    }
    mu.Lock()
    tmpl.DNS.Hosts[addr] = ips
    mu.Unlock()
}
```

And I've noticed that the `IsIPv6Supported` function consistently returns `false` on Windows when the environment config didn't specify, because the Windows Firewall doesn't rely on iptables or nftables. Therefore, I think for non-Linux systems, relying on the return value of `nettest.SupportsIPv6` is sufficient.

https://github.com/v2rayA/v2rayA/blob/df74d3cf12ade4abc2cfbc8be6ac58898254ce4e/service/core/iptables/utils.go#L42-L61

I have made the necessary adjustments in the pull request accordingly.