### PR TITLE
Remove "is-text" in button style

### DIFF
--- a/gui/src/components/modalSetting.vue
+++ b/gui/src/components/modalSetting.vue
@@ -32,7 +32,6 @@
         }}</span>
         <b-button
           size="is-small"
-          type="is-text"
           style="
             position: relative;
             top: -2px;


### PR DESCRIPTION
![image](https://github.com/v2rayA/v2rayA/assets/100271394/5cae09cb-df81-4079-8a47-2946859033a6)

The `update` button is text style. I did not recognized it is a button. I have some URL being blocked, I only can use `no split traffic` option. I asked help on Internet. I do not know why. one say the `update` is a button.

Please set it be more like a button

![image](https://github.com/v2rayA/v2rayA/assets/100271394/023da67c-c0cf-4a07-99bc-0fef580f453b)
