### PR TITLE
Add Support for QUIC Protocol in VLESS

### DIFF
--- a/gui/src/components/modalServer.vue
+++ b/gui/src/components/modalServer.vue
@@ -106,6 +106,13 @@
               </option>
             </b-select>
           </b-field>
+          <b-field v-show="v2ray.protocol === 'vless' && v2ray.net == 'quic'" label="QUIC Security" label-position="on-border">
+            <b-select v-model="v2ray.quicSecurity" expanded>
+              <option value="none">none</option>
+              <option value="aes-128-gcm">aes-128-gcm</option>
+              <option value="chacha20-poly1305">chacha20-poly1305</option>
+            </b-select>
+          </b-field>
           <b-field v-show="v2ray.net === 'kcp' || v2ray.net === 'quic'" label="Type" label-position="on-border">
             <b-select v-model="v2ray.type" expanded>
               <option value="none">
@@ -608,6 +615,7 @@ export default {
       host: "",
       path: "",
       tls: "none",
+      quicSecurity: "none",
       fp: "",
       pbk: "",
       sid: "",
@@ -814,6 +822,7 @@ export default {
           alpn: u.params.alpn || "",
           sni: u.params.sni || "",
           tls: u.params.security || "none",
+          quicSecurity: u.params.quicSecurity || "none",
           fp: u.params.fp || "",
           pbk: u.params.pbk || "",
           sid: u.params.sid || "",
@@ -1061,6 +1070,7 @@ export default {
           }
           if (srcObj.net === "quic") {
             query.key = srcObj.key;
+            query.quicSecurity = srcObj.quicSecurity;
           }
           if (query.security == "reality") {
             query.pbk = srcObj.pbk;

--- a/gui/src/components/modalServer.vue
+++ b/gui/src/components/modalServer.vue
@@ -93,6 +93,7 @@
               <option value="ws">WebSocket</option>
               <option value="h2">HTTP/2</option>
               <option value="grpc">gRPC</option>
+              <option value="quic">QUIC</option>
             </b-select>
           </b-field>
           <b-field v-show="v2ray.net === 'tcp'" label="Type" label-position="on-border">
@@ -105,7 +106,7 @@
               </option>
             </b-select>
           </b-field>
-          <b-field v-show="v2ray.net === 'kcp'" label="Type" label-position="on-border">
+          <b-field v-show="v2ray.net === 'kcp' || v2ray.net === 'quic'" label="Type" label-position="on-border">
             <b-select v-model="v2ray.type" expanded>
               <option value="none">
                 {{ $t("configureServer.noObfuscation") }}
@@ -152,6 +153,10 @@
           </b-field>
           <b-field v-show="v2ray.net === 'grpc'" label="Service Name" label-position="on-border">
             <b-input ref="v2ray_service_name" v-model="v2ray.path" type="text" expanded />
+          </b-field>
+          <b-field v-show="v2ray.net === 'quic'" label="Key" label-position="on-border">
+            <b-input ref="v2ray_key" v-model="v2ray.key" :placeholder="$t('configureServer.password')"
+              expanded />
           </b-field>
         </b-tab-item>
         <b-tab-item label="SS">
@@ -612,6 +617,7 @@ export default {
       v: "",
       allowInsecure: false,
       protocol: "vmess",
+      key: "none",
     },
     ss: {
       method: "aes-128-gcm",
@@ -813,6 +819,7 @@ export default {
           sid: u.params.sid || "",
           spx: u.params.spx || "",
           allowInsecure: u.params.allowInsecure || false,
+          key: u.params.key,
           protocol: "vless",
         };
         if (o.alpn !== "") {
@@ -1051,6 +1058,9 @@ export default {
           }
           if (srcObj.net === "mkcp" || srcObj.net === "kcp") {
             query.seed = srcObj.path;
+          }
+          if (srcObj.net === "quic") {
+            query.key = srcObj.key;
           }
           if (query.security == "reality") {
             query.pbk = srcObj.pbk;

--- a/service/core/coreObj/coreObj.go
+++ b/service/core/coreObj/coreObj.go
@@ -247,8 +247,9 @@ type HttpSettings struct {
 	Method string   `json:"method,omitempty"`
 }
 type QuicSettings struct {
-	Header KcpHeader `json:"header"`
-	Key    string    `json:"key,omitempty"`
+	Header   KcpHeader `json:"header"`
+	Key      string    `json:"key,omitempty"`
+	Security string    `json:"security"`
 }
 type Hosts map[string][]string
 

--- a/service/core/coreObj/coreObj.go
+++ b/service/core/coreObj/coreObj.go
@@ -149,6 +149,7 @@ type StreamSettings struct {
 	WsSettings      *WsSettings      `json:"wsSettings,omitempty"`
 	HTTPSettings    *HttpSettings    `json:"httpSettings,omitempty"`
 	GrpcSettings    *GrpcSettings    `json:"grpcSettings,omitempty"`
+	QuicSettings    *QuicSettings    `json:"quicSettings,omitempty"`
 	Sockopt         *Sockopt         `json:"sockopt,omitempty"`
 }
 type RealitySettings struct {
@@ -244,6 +245,10 @@ type HttpSettings struct {
 	Path   string   `json:"path"`
 	Host   []string `json:"host,omitempty"`
 	Method string   `json:"method,omitempty"`
+}
+type QuicSettings struct {
+	Header KcpHeader `json:"header"`
+	Key    string    `json:"key,omitempty"`
 }
 type Hosts map[string][]string
 

--- a/service/core/serverObj/v2ray.go
+++ b/service/core/serverObj/v2ray.go
@@ -50,6 +50,7 @@ type V2Ray struct {
 	Flow          string `json:"flow,omitempty"`
 	Alpn          string `json:"alpn,omitempty"`
 	AllowInsecure bool   `json:"allowInsecure"`
+	Key           string `json:"key,omitempty"`
 	V             string `json:"v"`
 	Protocol      string `json:"protocol"`
 }
@@ -87,6 +88,7 @@ func ParseVlessURL(vless string) (data *V2Ray, err error) {
 		Flow:          u.Query().Get("flow"),
 		Alpn:          u.Query().Get("alpn"),
 		AllowInsecure: u.Query().Get("allowInsecure") == "true",
+		Key:           u.Query().Get("key"),
 		V:             vless,
 		Protocol:      "vless",
 	}
@@ -355,6 +357,13 @@ func (v *V2Ray) Configuration(info PriorInfo) (c Configuration, err error) {
 					Path: v.Path,
 				}
 			}
+		case "quic":
+			core.StreamSettings.QuicSettings = &coreObj.QuicSettings{
+				Header: coreObj.KcpHeader{
+					Type: v.Type,
+				},
+				Key: v.Key,
+			}
 		default:
 			return Configuration{}, fmt.Errorf("unexpected transport type: %v", v.Net)
 		}
@@ -444,6 +453,9 @@ func (v *V2Ray) ExportToURL() string {
 			setValue(&query, "path", v.Path)
 		case "grpc":
 			setValue(&query, "serviceName", v.Path)
+		case "quic":
+			setValue(&query, "headerType", v.Type)
+			setValue(&query, "key", v.Key)
 		}
 		if v.TLS != "none" {
 			setValue(&query, "flow", v.Flow)

--- a/service/core/serverObj/v2ray.go
+++ b/service/core/serverObj/v2ray.go
@@ -51,6 +51,7 @@ type V2Ray struct {
 	Alpn          string `json:"alpn,omitempty"`
 	AllowInsecure bool   `json:"allowInsecure"`
 	Key           string `json:"key,omitempty"`
+	QuicSecurity  string `json:"quicSecurity"`
 	V             string `json:"v"`
 	Protocol      string `json:"protocol"`
 }
@@ -109,6 +110,9 @@ func ParseVlessURL(vless string) (data *V2Ray, err error) {
 	}
 	if data.Net == "mkcp" || data.Net == "kcp" {
 		data.Path = u.Query().Get("seed")
+	}
+	if data.Net == "quic" {
+		data.QuicSecurity = u.Query().Get("quicSecurity")
 	}
 	return data, nil
 }
@@ -362,7 +366,8 @@ func (v *V2Ray) Configuration(info PriorInfo) (c Configuration, err error) {
 				Header: coreObj.KcpHeader{
 					Type: v.Type,
 				},
-				Key: v.Key,
+				Key:      v.Key,
+				Security: v.QuicSecurity,
 			}
 		default:
 			return Configuration{}, fmt.Errorf("unexpected transport type: %v", v.Net)
@@ -456,6 +461,7 @@ func (v *V2Ray) ExportToURL() string {
 		case "quic":
 			setValue(&query, "headerType", v.Type)
 			setValue(&query, "key", v.Key)
+			setValue(&query, "quicSecurity", v.QuicSecurity)
 		}
 		if v.TLS != "none" {
 			setValue(&query, "flow", v.Flow)


### PR DESCRIPTION
## Changes:
Added support for the QUIC protocol in VLESS configuration

## Question:
Why is the `scy` field used for the `TLS` field in the ParseVlessURL function?
I was planning to add encryption options like aes-128-gcm and chacha20-poly1305, but I noticed that the scy field is being used for TLS in the ParseVlessURL function. Could you explain the reasoning behind this usage?

---
Please review and provide feedback. Thank you!