### PR TITLE
Added support to protocol: 2022-blake3-aes-128-gcm and 2 more. Fixed bug while using xray-core.

### DIFF
--- a/gui/src/components/modalServer.vue
+++ b/gui/src/components/modalServer.vue
@@ -34,8 +34,13 @@
           <b-field v-if="v2ray.protocol === 'vmess'" label="Security" label-position="on-border">
             <b-select v-model="v2ray.scy" expanded required>
               <option value="auto">Auto</option>
+              <option value="2022-blake3-aes-128-gcm">2022-blake3-aes-128-gcm</option>
+              <option value="2022-blake3-aes-256-gcm">2022-blake3-aes-256-gcm</option>
+              <option value="2022-blake3-chacha20-poly1305">2022-blake3-chacha20-poly1305</option>
+              <option value="aes-256-gcm">aes-256-gcm</option>
               <option value="aes-128-gcm">aes-128-gcm</option>
               <option value="chacha20-poly1305">chacha20-poly1305</option>
+              <option value="xchacha20-poly1305">xchacha20-poly1305</option>
               <option value="none">none</option>
               <option value="zero">zero</option>
             </b-select>
@@ -183,6 +188,9 @@
           </b-field>
           <b-field label="Method" label-position="on-border">
             <b-select ref="ss_method" v-model="ss.method" expanded required>
+              <option value="2022-blake3-aes-128-gcm">2022-blake3-aes-128-gcm</option>
+              <option value="2022-blake3-aes-256-gcm">2022-blake3-aes-256-gcm</option>
+              <option value="2022-blake3-chacha20-poly1305">2022-blake3-chacha20-poly1305</option>
               <option value="aes-128-gcm">aes-128-gcm</option>
               <option value="aes-256-gcm">aes-256-gcm</option>
               <option value="chacha20-poly1305">chacha20-poly1305</option>
@@ -628,7 +636,7 @@ export default {
       key: "none",
     },
     ss: {
-      method: "aes-128-gcm",
+      method: "2022-blake3-aes-128-gcm",
       plugin: "",
       obfs: "http",
       tls: "",
@@ -955,7 +963,7 @@ export default {
           method: "origin",
           net: u.params.type || "tcp",
           obfs: "none",
-          ssCipher: "aes-128-gcm",
+          ssCipher: "2022-blake3-aes-128-gcm",
           path: u.params.path || u.params.serviceName || "",
           protocol: "trojan",
         };

--- a/service/core/serverObj/shadowsocks.go
+++ b/service/core/serverObj/shadowsocks.go
@@ -327,7 +327,7 @@ func (s *Shadowsocks) ConfigurationMT(info PriorInfo) (c Configuration, err erro
 
 func (s *Shadowsocks) Configuration(info PriorInfo) (c Configuration, err error) {
 	switch s.Cipher {
-	case "aes-256-gcm", "aes-128-gcm", "chacha20-poly1305", "chacha20-ietf-poly1305", "plain", "none":
+	case "2022-blake3-aes-128-gcm", "2022-blake3-aes-256-gcm", "2022-blake3-chacha20-poly1305", "aes-256-gcm", "aes-128-gcm", "chacha20-poly1305", "chacha20-ietf-poly1305", "xchacha20-poly1305", "xchacha20-ietf-poly1305", "plain", "none":
 	default:
 		return c, fmt.Errorf("unsupported shadowsocks encryption method: %v", s.Cipher)
 	}
@@ -379,6 +379,9 @@ func (s *Shadowsocks) ProtoToShow() string {
 	ciph := s.Cipher
 	if ciph == "chacha20-ietf-poly1305" || ciph == "chacha20-poly1305" {
 		ciph = "c20p1305"
+	}
+	if ciph == "xchacha20-ietf-poly1305" || ciph == "xchacha20-poly1305" {
+		ciph = "xc20p1305"
 	}
 	if s.Plugin.Name != "" {
 		return fmt.Sprintf("SS(%v+%v)", ciph, s.Plugin.Name)

--- a/service/pkg/plugin/ss/ss.go
+++ b/service/pkg/plugin/ss/ss.go
@@ -34,6 +34,9 @@ func NewShadowsocks(s string, d plugin.Dialer) (*Shadowsocks, error) {
 	if method == "chacha20-poly1305" {
 		method = "chacha20-ietf-poly1305"
 	}
+	if method == "xchacha20-poly1305" {
+		method = "xchacha20-ietf-poly1305"
+	}
 	cipher, err := ss.PickCipher(method, nil, pass)
 	if err != nil {
 		return nil, fmt.Errorf("NewShadowsocks: %w", err)


### PR DESCRIPTION
While using v2rayA with xray-core as the substitution of v2ray-core, it prompts an error says `failed to start v2ray-core: unsupported shadowsocks encryption method: 2022-blake3-aes-128-gcm` while clicking on 'start'. However, xray-core explicitly supports 2022-blake3-aes-128-gcm, 2022-blake3-aes-256-gcm and 2022-blake3-chacha20-poly1305. Therefore, there should not be this error.

I added a few modification (very few, easy to compare), and problem solved. I believe that many customers has the same problem, so hope you can check them and merge them into the main branch please. (Or if you suggest me to create a new feature branch, please let me know.)