### PR TITLE
fix(gui): trojan with no obfuscation won't be selected

### DIFF
--- a/gui/src/components/modalServer.vue
+++ b/gui/src/components/modalServer.vue
@@ -1410,16 +1410,8 @@ export default {
             o.ssCipher = fields[1];
             o.ssPassword = fields[2];
           }
-          const obfsMap = {
-            original: "none",
-            "": "none",
-            ws: "websocket",
-          };
-          o.obfs = obfsMap[u.params.type || ""];
-          if (o.obfs === "ws") {
+          if (u.params.type === "ws") {
             o.obfs = "websocket";
-          }
-          if (o.obfs === "websocket") {
             o.host = u.params.host || "";
             o.path = u.params.path || "/";
           }


### PR DESCRIPTION
Every time I tried to edit my trojan node with no obfuscation, the option of obfs won't be selected for a undefined variable.

It seems that only those nodes whose type is ws/websocket will have the ability to have obfs, so just delete the map, do the judgement by if sentence.