### PR TITLE
change trojan ws path url param name from "serviceName" to "path" to fit v2rayN's export format.

### DIFF
--- a/service/core/serverObj/trojan.go
+++ b/service/core/serverObj/trojan.go
@@ -69,7 +69,7 @@ func ParseTrojanURL(u string) (data *Trojan, err error) {
 		Sni:           sni,
 		Alpn:          t.Query().Get("alpn"),
 		Type:          t.Query().Get("type"),
-		Path:          t.Query().Get("serviceName"),
+		Path:          t.Query().Get("path"),
 		AllowInsecure: allowInsecure == "1" || allowInsecure == "true",
 		Protocol:      "trojan",
 	}


### PR DESCRIPTION
I'm not sure why the param name of Websocket Path
is serviceName now, but the v2rayN export format is like: trojan://passwd@host:port?security=tls&type=ws&host=foo.bar.com&path=%2Fpath#remarks.