### PR TITLE
Avoid routing Private Google Access traffic over v2rayA

### DIFF
--- a/service/core/iptables/redirect.go
+++ b/service/core/iptables/redirect.go
@@ -65,6 +65,8 @@ iptables -w 2 -t nat -A TP_RULE -d 192.168.0.0/16 -j RETURN
 # fakedns
 # iptables -w 2 -t nat -A TP_RULE -d 198.18.0.0/15 -j RETURN
 iptables -w 2 -t nat -A TP_RULE -d 198.51.100.0/24 -j RETURN
+iptables -w 2 -t nat -A TP_RULE -d 199.36.153.8/30 -j RETURN # private.googleapis.com
+iptables -w 2 -t nat -A TP_RULE -d 199.36.153.4/30 -j RETURN # restricted.googleapis.com
 iptables -w 2 -t nat -A TP_RULE -d 203.0.113.0/24 -j RETURN
 iptables -w 2 -t nat -A TP_RULE -d 224.0.0.0/4 -j RETURN
 iptables -w 2 -t nat -A TP_RULE -d 240.0.0.0/4 -j RETURN
@@ -89,6 +91,8 @@ ip6tables -w 2 -t nat -A TP_RULE -d 2001::/32 -j RETURN
 ip6tables -w 2 -t nat -A TP_RULE -d 2001:20::/28 -j RETURN
 ip6tables -w 2 -t nat -A TP_RULE -d 2001:db8::/32 -j RETURN
 ip6tables -w 2 -t nat -A TP_RULE -d 2002::/16 -j RETURN
+ip6tables -w 2 -t nat -A TP_RULE -d 2600:2d00:0002:2000::/64 -j RETURN # private.googleapis.com
+ip6tables -w 2 -t nat -A TP_RULE -d 2600:2d00:0002:1000::/64 -j RETURN # restricted.googleapis.com
 # fakedns
 # ip6tables -w 2 -t nat -A TP_RULE -d fc00::/7 -j RETURN
 ip6tables -w 2 -t nat -A TP_RULE -d fe80::/10 -j RETURN
@@ -171,6 +175,8 @@ table inet v2raya {
             192.88.99.0/24,
             192.168.0.0/16,
             198.51.100.0/24,
+            199.36.153.8/30, # private.googleapis.com
+            199.36.153.4/30, # restricted.googleapis.com
             203.0.113.0/24,
             224.0.0.0/4,
             240.0.0.0/4
@@ -188,6 +194,8 @@ table inet v2raya {
             100::/64,
             2001::/32,
             2001:20::/28,
+            2600:2d00:0002:2000::/64, # private.googleapis.com
+            2600:2d00:0002:1000::/64, # restricted.googleapis.com
             fe80::/10,
             ff00::/8
         }

--- a/service/core/iptables/tproxy.go
+++ b/service/core/iptables/tproxy.go
@@ -120,6 +120,8 @@ iptables -w 2 -t mangle -A TP_RULE -d 192.168.0.0/16 -j RETURN
 # fakedns
 # iptables -w 2 -t mangle -A TP_RULE -d 198.18.0.0/15 -j RETURN
 iptables -w 2 -t mangle -A TP_RULE -d 198.51.100.0/24 -j RETURN
+iptables -w 2 -t mangle -A TP_RULE -d 199.36.153.8/30 -j RETURN # private.googleapis.com
+iptables -w 2 -t mangle -A TP_RULE -d 199.36.153.4/30 -j RETURN # restricted.googleapis.com
 iptables -w 2 -t mangle -A TP_RULE -d 203.0.113.0/24 -j RETURN
 iptables -w 2 -t mangle -A TP_RULE -d 224.0.0.0/4 -j RETURN
 iptables -w 2 -t mangle -A TP_RULE -d 240.0.0.0/4 -j RETURN
@@ -177,6 +179,8 @@ ip6tables -w 2 -t mangle -A TP_RULE -d 64:ff9b::/96 -j RETURN
 ip6tables -w 2 -t mangle -A TP_RULE -d 100::/64 -j RETURN
 ip6tables -w 2 -t mangle -A TP_RULE -d 2001::/32 -j RETURN
 ip6tables -w 2 -t mangle -A TP_RULE -d 2001:20::/28 -j RETURN
+ip6tables -w 2 -t mangle -A TP_RULE -d 2600:2d00:0002:2000::/64 -j RETURN # private.googleapis.com
+ip6tables -w 2 -t mangle -A TP_RULE -d 2600:2d00:0002:1000::/64 -j RETURN # restricted.googleapis.com
 ip6tables -w 2 -t mangle -A TP_RULE -d fe80::/10 -j RETURN
 ip6tables -w 2 -t mangle -A TP_RULE -d ff00::/8 -j RETURN
 ip6tables -w 2 -t mangle -A TP_RULE -j TP_MARK
@@ -265,6 +269,8 @@ table inet v2raya {
             192.88.99.0/24,
             192.168.0.0/16,
             198.51.100.0/24,
+            199.36.153.8/30, # private.googleapis.com
+            199.36.153.4/30, # restricted.googleapis.com
             203.0.113.0/24,
             224.0.0.0/4,
             240.0.0.0/4
@@ -282,6 +288,8 @@ table inet v2raya {
             100::/64,
             2001::/32,
             2001:20::/28,
+            2600:2d00:0002:2000::/64, # private.googleapis.com
+            2600:2d00:0002:1000::/64, # restricted.googleapis.com
             fe80::/10,
             ff00::/8
         }


### PR DESCRIPTION
We have some on-prem hosts with routes configured for Private Google Access. Unfortunately v2rayA interferes with the traffic by trying to proxy it then sends it over to the public Google endpoints. Using v2ray routing doesn't seem to help, because Private Google Access requires traffic to be sent to the private virtual IPs with Host header and SNI pointing to the public service names, and v2ray resolves them to the public IP addresses corresponding to the service names used.

Ref: https://cloud.google.com/vpc/docs/configure-private-google-access-hybrid