### PR TITLE
chore(docker,ci): add riscv64 to docker build

### DIFF
--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -733,7 +733,7 @@ jobs:
         context: .
         builder: ${{ steps.buildx.outputs.name }}
         file: install/docker/Dockerfile.Action
-        platforms: linux/arm,linux/arm64,linux/amd64
+        platforms: linux/arm,linux/arm64,linux/amd64,linux/riscv64
         push: true
         tags: |
           ${{ steps.prep.outputs.image }}:${{ steps.prep.outputs.tag }}

--- a/install/docker/docker_helper.sh
+++ b/install/docker/docker_helper.sh
@@ -14,6 +14,10 @@ case "$(arch)" in
         v2ray_arch="arm64-v8a"
         v2raya_arch="arm64"
         ;;
+    riscv64)
+        v2ray_arch="riscv64"
+        v2raya_arch="riscv64"
+        ;;
     *)
         ;;
 esac


### PR DESCRIPTION
Add riscv64 to docker build.

Tested build with the following command successfully:
```bash
$ export version=2.2.6.2
$ sed -i "s|Realv2rayAVersion|$version|g" install/docker/docker_helper.sh
$ docker build -t ngc7331/v2raya:latest --platform linux/riscv64 -f install/docker/Dockerfile.Action --push .
```

Image: https://hub.docker.com/repository/docker/ngc7331/v2raya/tags

Tested on a Milk-V Mars board and everything works fine:
```bash
$ neofetch
       _,met$$$$$gg.          user@MarsCM 
    ,g$$$$$$$$$$$$$$$P.       ------------ 
  ,g$$P"     """Y$$.".        OS: Debian GNU/Linux trixie/sid riscv64 
 ,$$P'              `$$$.     Host: Milk-V Mars CM eMMC 
',$$P       ,ggs.     `$$b:   Kernel: 5.15.0-xu.2 
`d$$'     ,$P"'   .    $$$    Uptime: 10 mins 
 $$P      d$'     ,    $$P    Packages: 1251 (dpkg) 
 $$:      $$.   -    ,d$$'    Shell: zsh 5.9 
 $$;      Y$b._   _,d$P'      Terminal: /dev/pts/0 
 Y$$.    `.`"Y$$$$P"'         CPU: (4) @ 1.500GHz 
 `$$b      "-.__              Memory: 304MiB / 3866MiB 
  `Y$$
   `Y$$.                                              
     `$$b.                                            
       `Y$$b.
          `"Y$b._
              `"""

$ docker run -d \              
  -p 2017:2017 \
  -p 20170-20172:20170-20172 \
  --restart=always \
  --name v2raya \
  -e V2RAYA_V2RAY_BIN=/usr/local/bin/xray \ 
  -v /etc/v2raya:/etc/v2raya \
  ngc7331/v2raya
05f46ee19e50977af570ee442318112a19146e1e0b4514da76cad8aaa0f410f6

$ docker logs v2raya
2024/11/24 07:14:57.620 [A] [main.go:29]  V2Ray binary is /usr/local/bin/xray
2024/11/24 07:14:57.621 [A] [main.go:29]  V2Ray asset directory is /run/user/0/v2raya
2024/11/24 07:14:57.621 [A] [main.go:29]  v2rayA working directory is /
2024/11/24 07:14:57.621 [A] [main.go:29]  v2rayA configuration directory is /etc/v2raya
2024/11/24 07:14:57.621 [A] [main.go:29]  Golang: go1.23.2
2024/11/24 07:14:57.621 [A] [main.go:29]  OS: linux
2024/11/24 07:14:57.621 [A] [main.go:29]  Arch: riscv64
2024/11/24 07:14:57.622 [A] [main.go:29]  Lite: false
2024/11/24 07:14:57.622 [A] [main.go:29]  Version: 2.2.6.2
2024/11/24 07:14:57.622 [A] [main.go:29]  Starting...
2024/11/24 07:14:57.622 [I] [main.go:30]  the core was not running the last time v2rayA exited
2024/11/24 07:14:57.652 [A] [index.go:116]  v2rayA is listening at http://127.0.0.1:2017
2024/11/24 07:14:57.652 [A] [index.go:116]  v2rayA is listening at http://172.17.0.3:2017
2024/11/24 07:14:57.652 [A] [index.go:116]  v2rayA is listening at http://[::1]:2017
```

Unfortunately, `v2raya-gui` is currently unable to add riscv64 support, as the base image `nginx` has not yet merged riscv64 support: https://github.com/nginxinc/docker-nginx/pull/898. Unless we use `alpine` as the base image and install nginx manually, which is too much work.