### PR TITLE
fix: core startup timeout on old devices

### DIFF
--- a/service/core/v2ray/process.go
+++ b/service/core/v2ray/process.go
@@ -151,7 +151,7 @@ func NewProcess(tmpl *Template,
 			}
 			return nil, fmt.Errorf("unexpected exiting: check the log for more information")
 		}
-		if time.Since(startTime) > 15*time.Second {
+		if time.Since(startTime) > 30*time.Second {
 			return nil, fmt.Errorf("timeout: check the log for more information")
 		}
 		time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
- On older devices, 15 seconds is not enough time to start xray, which will result in webui showing startup failure before xray is successfully started, at which point the already started xray process will not be destroyed by v2raya, which will result in memory exhaustion by xray if webui is clicked to start multiple times.