### PR TITLE
fix: websocket for subpath support

### DIFF
--- a/ngui/pages/log.vue
+++ b/ngui/pages/log.vue
@@ -6,7 +6,7 @@ definePageMeta({ middleware: ['auth'] })
 const message = $ref<string[]>([])
 
 const parsed = parseURL(system.value.api)
-const socket = new WebSocket(`ws://${parsed.host}/api/message?Authorization=${encodeURIComponent(user.value.token)}`)
+const socket = new WebSocket(`ws://${parsed.host}${parsed.pathname}/api/message?Authorization=${encodeURIComponent(user.value.token)}`)
 
 socket.onmessage = (msg) => { message.push(msg.data) }
 </script>


### PR DESCRIPTION
fix for v2ray instances hosted on `https://<domain.fqdn>/subpath`

websocket address was `https://<domain.fqdn>/api/message`