### PR TITLE
fix windows Syscall Deprecated

### DIFF
--- a/service/core/iptables/systemProxy_windows.go
+++ b/service/core/iptables/systemProxy_windows.go
@@ -51,7 +51,7 @@ var (
 )
 
 func GetCurrentThread() (pseudoHandle windows.Handle, err error) {
-	r0, _, e1 := syscall.Syscall(procGetCurrentThread.Addr(), 0, 0, 0, 0)
+	r0, _, e1 := syscall.SyscallN(procGetCurrentThread.Addr(), 0, 0, 0, 0)
 	pseudoHandle = windows.Handle(r0)
 	if pseudoHandle == 0 {
 		if e1 != 0 {
@@ -70,7 +70,7 @@ func OpenThreadToken(h windows.Handle, access uint32, self bool, token *windows.
 	} else {
 		_p0 = 0
 	}
-	r1, _, e1 := syscall.Syscall6(procOpenThreadToken.Addr(), 4, uintptr(h), uintptr(access), uintptr(_p0), uintptr(unsafe.Pointer(token)), 0, 0)
+	r1, _, e1 := syscall.SyscallN(procOpenThreadToken.Addr(), 4, uintptr(h), uintptr(access), uintptr(_p0), uintptr(unsafe.Pointer(token)), 0, 0)
 	if r1 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)
@@ -82,7 +82,7 @@ func OpenThreadToken(h windows.Handle, access uint32, self bool, token *windows.
 }
 
 func ImpersonateSelf() (err error) {
-	r0, _, e1 := syscall.Syscall(procImpersonateSelf.Addr(), 1, uintptr(2), 0, 0)
+	r0, _, e1 := syscall.SyscallN(procImpersonateSelf.Addr(), 1, uintptr(2), 0, 0)
 	if r0 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)
@@ -94,7 +94,7 @@ func ImpersonateSelf() (err error) {
 }
 
 func RevertToSelf() (err error) {
-	r0, _, e1 := syscall.Syscall(procRevertToSelf.Addr(), 0, 0, 0, 0)
+	r0, _, e1 := syscall.SyscallN(procRevertToSelf.Addr(), 0, 0, 0, 0)
 	if r0 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)
@@ -150,7 +150,7 @@ func InternetOptionSettingsChanged() (syscall.Handle, error) {
 	p2 := uint64(INTERNET_OPTION_SETTINGS_CHANGED)
 	p3 := uint16(0)
 	p4 := uint64(0)
-	r1, _, e1 := syscall.Syscall6(
+	r1, _, e1 := syscall.SyscallN(
 		procInternetSetOptionW.Addr(),
 		4,
 		uintptr(p1),


### PR DESCRIPTION
// Deprecated: Use [SyscallN] instead.
func Syscall(trap, nargs, a1, a2, a3 uintptr) (r1, r2 uintptr, err Errno)

// Deprecated: Use [SyscallN] instead.
func Syscall6(trap, nargs, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err Errno)

windows Syscall is deprecated, use SyscallN