### PR TITLE
Support for automatic rotation if vmess ports ranges.

### DIFF
--- a/gui/src/components/modalServer.vue
+++ b/gui/src/components/modalServer.vue
@@ -24,6 +24,10 @@
             <b-input ref="v2ray_port" v-model="v2ray.port" required :placeholder="$t('configureServer.port')"
               type="number" expanded />
           </b-field>
+          <b-field label="Ports" label-position="on-border">
+            <b-input ref="v2ray_port" v-model="v2ray.ports" required placeholder="exp. 2000-3000"
+              expanded />
+          </b-field>
           <b-field label="ID" label-position="on-border">
             <b-input ref="v2ray_id" v-model="v2ray.id" required placeholder="UserID" expanded />
           </b-field>
@@ -612,6 +616,7 @@ export default {
       ps: "",
       add: "",
       port: "",
+      ports: "",
       id: "",
       flow: "",
       aid: "",

--- a/service/conf/variable.go
+++ b/service/conf/variable.go
@@ -9,6 +9,7 @@ var (
 	FoundNew                 = false
 	RemoteVersion            = ""
 	TickerUpdateGFWList      *time.Ticker
+	TickerUpdateServers      *time.Ticker
 	TickerUpdateSubscription *time.Ticker
 )
 

--- a/service/pre.go
+++ b/service/pre.go
@@ -258,6 +258,7 @@ func updateSubscriptions() {
 
 func initUpdatingTicker() {
 	conf.TickerUpdateGFWList = time.NewTicker(24 * time.Hour * 365 * 100)
+	conf.TickerUpdateServers = time.NewTicker(30 * time.Minute)
 	conf.TickerUpdateSubscription = time.NewTicker(24 * time.Hour * 365 * 100)
 	go func() {
 		for range conf.TickerUpdateGFWList.C {
@@ -270,6 +271,11 @@ func initUpdatingTicker() {
 	go func() {
 		for range conf.TickerUpdateSubscription.C {
 			updateSubscriptions()
+		}
+	}()
+	go func() {
+		for range conf.TickerUpdateServers.C {
+			service.AutoIncrease()
 		}
 	}()
 }

--- a/service/server/controller/subscription.go
+++ b/service/server/controller/subscription.go
@@ -5,6 +5,7 @@ import (
 	"github.com/v2rayA/v2rayA/common"
 	"github.com/v2rayA/v2rayA/core/touch"
 	"github.com/v2rayA/v2rayA/db/configure"
+	"github.com/v2rayA/v2rayA/pkg/util/log"
 	"github.com/v2rayA/v2rayA/server/service"
 )
 
@@ -57,4 +58,26 @@ func PutSubscription(ctx *gin.Context) {
 		return
 	}
 	getTouch(ctx)
+}
+
+// 获订阅
+func GetSubscription(ctx *gin.Context) {
+	// Get connected configures
+	css := configure.GetConnectedServers()
+	if css.Len() == 0 {
+		ctx.String(200, "")
+	}
+
+	server := configure.GetServers()
+
+	s := ""
+	for _, cs := range css.Get() {
+		if cs.ID <= 0 || cs.ID > len(server) {
+			log.Info("AutoIncrease: ID ", cs.ID, len(server))
+			continue
+		}
+		ind := cs.ID - 1
+		s += server[ind].ServerObj.ExportToURL() + "\n"
+	}
+	ctx.String(200, s)
 }

--- a/service/server/router/index.go
+++ b/service/server/router/index.go
@@ -149,6 +149,8 @@ func Run() error {
 		noAuth.GET("version", controller.GetVersion)
 		noAuth.POST("login", controller.PostLogin)
 		noAuth.POST("account", controller.PostAccount)
+
+		noAuth.GET("sub", controller.GetSubscription)
 	}
 	auth := engine.Group("api",
 		nocache,

--- a/service/server/service/ports.go
+++ b/service/server/service/ports.go
@@ -1,12 +1,18 @@
 package service
 
 import (
+	"encoding/json"
 	"fmt"
-	"github.com/go-leo/slicex"
-	"github.com/v2rayA/v2rayA/core/v2ray"
-	"github.com/v2rayA/v2rayA/db/configure"
 	"reflect"
 	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-leo/slicex"
+	"github.com/v2rayA/v2rayA/core/serverObj"
+	"github.com/v2rayA/v2rayA/core/v2ray"
+	"github.com/v2rayA/v2rayA/db/configure"
+	"github.com/v2rayA/v2rayA/pkg/util/log"
 )
 
 func GetPorts() configure.Ports {
@@ -90,4 +96,114 @@ func SetPorts(ports *configure.Ports) (err error) {
 		err = v2ray.UpdateV2RayConfig()
 	}
 	return
+}
+
+// AutoIncrease tries to increase ports automatically when ports are disabled. Only supports servers.
+func AutoIncrease() {
+	log.Info("AutoIncrease: start to auto increase vmess ports")
+	// Get connected configures
+	css := configure.GetConnectedServers()
+	if css.Len() == 0 {
+		log.Info("AutoIncrease: GetConnectedServers empty")
+		return
+	}
+
+	server := configure.GetServers()
+
+	b, e := json.Marshal(css)
+	log.Info("AutoIncrease: css:", string(b), e)
+	s, e := json.Marshal(server)
+	log.Info("AutoIncrease: server", string(s), e)
+
+	// Get servers from connected configures which are vmess protocol and have ports seted
+	srvWt := make([]*configure.Which, 0, css.Len())
+	for _, cs := range css.Get() {
+		if cs.TYPE != configure.ServerType {
+			continue
+		}
+		if cs.ID <= 0 || cs.ID > len(server) {
+			log.Info("AutoIncrease: ID ", cs.ID, len(server))
+			continue
+		}
+		ind := cs.ID - 1
+		if server[ind].ServerObj.GetProtocol() != "vmess" {
+			log.Info("AutoIncrease: Protocol ", server[ind].ServerObj.GetProtocol(), "vmess")
+			continue
+		}
+
+		v2, err := serverObj.ParseVmessURL(server[ind].ServerObj.ExportToURL())
+		if err != nil {
+			log.Error("AutoIncrease: parse vmess url error: %v", err)
+			continue
+		}
+
+		if v2.Ports == "" {
+			continue
+		}
+		srvWt = append(srvWt, cs)
+	}
+	if len(srvWt) == 0 {
+		log.Info("AutoIncrease: srvWt empty")
+		return
+	}
+
+	wt, err := Ping(srvWt, 5*time.Second)
+	if err != nil {
+		log.Error("AutoIncrease: %v", err)
+		return
+	}
+
+	for _, w := range wt {
+		if w.Latency != "TIMEOUT" && w.Latency != "" {
+			continue
+		}
+		srv := server[w.ID-1]
+		v2, err := serverObj.ParseVmessURL(srv.ServerObj.ExportToURL())
+		if err != nil {
+			log.Error("AutoIncrease: parse vmess url error: %v", err)
+			continue
+		}
+		ports, err := parsePorts(v2.Ports)
+		if err != nil {
+			log.Error("AutoIncrease: parse vmess ports error: %v", err)
+			continue
+		}
+		if p, _ := strconv.Atoi(v2.Port); p >= ports[1] {
+			v2.Port = strconv.Itoa(ports[0])
+		} else {
+			v2.Port = strconv.Itoa(p + 1)
+		}
+		log.Info("update server port to ", v2.Port)
+
+		err = Import(v2.ExportToURL(), w)
+		if err != nil {
+			log.Error("AutoIncrease: import vmess url error: %v", err)
+			continue
+		}
+	}
+}
+
+func parsePorts(portsStr string) (ports []int, err error) {
+	if portsStr == "" {
+		return
+	}
+	s := strings.Split(portsStr, "-")
+	if len(s) != 2 {
+		return nil, fmt.Errorf("invalid ports syntax")
+	}
+	start, err := strconv.Atoi(s[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid ports syntax")
+	}
+	end, err := strconv.Atoi(s[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid ports syntax")
+	}
+	if start > end || start <= 0 || end > 65535 {
+		return nil, fmt.Errorf("invalid ports syntax")
+	}
+	ports = make([]int, 2)
+	ports[0] = start
+	ports[1] = end
+	return ports, nil
 }


### PR DESCRIPTION
v2ray服务端支持监听一个ip段，如：2000-3000；
鉴于当前墙IP的周期越来越短，因此想
1、v2rayA支持自动检测连通性和自动轮转。
2、添加订阅接口支持；这样其他客户端仅需配置订阅，并设置自动更新订阅或者使用前点击更新订阅即可。
当前自用三个月，可靠。因为是自用，所以代码写的比较简陋，此PR仅作建议支持和特性参考。