### PR TITLE
Add subscription refresh and reselect workflow API

### DIFF
--- a/service/conf/environmentConfig.go
+++ b/service/conf/environmentConfig.go
@@ -52,7 +52,7 @@ func initFunc() {
 		EnvPrefix:         "V2RAYA_",
 	})
 	if err != nil {
-		if err.Error() != "unexpected word while parsing flags: '-test.v'" {
+		if !strings.HasPrefix(err.Error(), "unexpected word while parsing flags: '-test.") {
 			log2.Fatal(err)
 		}
 	}

--- a/service/server/controller/workflow.go
+++ b/service/server/controller/workflow.go
@@ -1,0 +1,40 @@
+package controller
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/v2rayA/v2rayA/common"
+	"github.com/v2rayA/v2rayA/server/service"
+)
+
+var refreshSubscriptionAndReselect = service.RefreshSubscriptionAndReselect
+
+type refreshSubscriptionAndReselectRequest struct {
+	SubscriptionID int `json:"subscriptionId"`
+}
+
+func PostRefreshSubscriptionAndReselect(ctx *gin.Context) {
+	updatingMu.Lock()
+	if updating {
+		common.ResponseError(ctx, processingErr)
+		updatingMu.Unlock()
+		return
+	}
+	updating = true
+	updatingMu.Unlock()
+	defer func() {
+		updatingMu.Lock()
+		updating = false
+		updatingMu.Unlock()
+	}()
+
+	var data refreshSubscriptionAndReselectRequest
+	if err := ctx.ShouldBindJSON(&data); err != nil || data.SubscriptionID <= 0 {
+		common.ResponseError(ctx, logError("bad request: invalid subscriptionId"))
+		return
+	}
+	if err := refreshSubscriptionAndReselect(data.SubscriptionID - 1); err != nil {
+		common.ResponseError(ctx, logError(err))
+		return
+	}
+	getTouch(ctx)
+}

--- a/service/server/controller/workflow.go
+++ b/service/server/controller/workflow.go
@@ -7,6 +7,7 @@ import (
 )
 
 var refreshSubscriptionAndReselect = service.RefreshSubscriptionAndReselect
+var respondWorkflowTouch = getTouch
 
 type refreshSubscriptionAndReselectRequest struct {
 	SubscriptionID int `json:"subscriptionId"`
@@ -36,5 +37,5 @@ func PostRefreshSubscriptionAndReselect(ctx *gin.Context) {
 		common.ResponseError(ctx, logError(err))
 		return
 	}
-	getTouch(ctx)
+	respondWorkflowTouch(ctx)
 }

--- a/service/server/controller/workflow_test.go
+++ b/service/server/controller/workflow_test.go
@@ -1,0 +1,74 @@
+package controller
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestPostRefreshSubscriptionAndReselectBadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	updating = false
+
+	req := httptest.NewRequest(http.MethodPost, "/api/workflow/refresh-subscription-and-reselect", bytes.NewBufferString(`{"subscriptionId":0}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = req
+
+	PostRefreshSubscriptionAndReselect(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: %d", rec.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if body["code"] != "FAIL" {
+		t.Fatalf("unexpected response code: %#v", body["code"])
+	}
+}
+
+func TestPostRefreshSubscriptionAndReselectSuccess(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	updating = false
+
+	original := refreshSubscriptionAndReselect
+	t.Cleanup(func() {
+		refreshSubscriptionAndReselect = original
+		updating = false
+	})
+
+	calledWith := -1
+	refreshSubscriptionAndReselect = func(index int) error {
+		calledWith = index
+		return nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/workflow/refresh-subscription-and-reselect", bytes.NewBufferString(`{"subscriptionId":3}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = req
+
+	PostRefreshSubscriptionAndReselect(ctx)
+
+	if calledWith != 2 {
+		t.Fatalf("expected service call with index 2, got %d", calledWith)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: %d", rec.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if body["code"] != "SUCCESS" {
+		t.Fatalf("unexpected response code: %#v", body["code"])
+	}
+}

--- a/service/server/controller/workflow_test.go
+++ b/service/server/controller/workflow_test.go
@@ -39,8 +39,10 @@ func TestPostRefreshSubscriptionAndReselectSuccess(t *testing.T) {
 	updating = false
 
 	original := refreshSubscriptionAndReselect
+	originalTouch := respondWorkflowTouch
 	t.Cleanup(func() {
 		refreshSubscriptionAndReselect = original
+		respondWorkflowTouch = originalTouch
 		updating = false
 	})
 
@@ -48,6 +50,9 @@ func TestPostRefreshSubscriptionAndReselectSuccess(t *testing.T) {
 	refreshSubscriptionAndReselect = func(index int) error {
 		calledWith = index
 		return nil
+	}
+	respondWorkflowTouch = func(ctx *gin.Context) {
+		ctx.JSON(http.StatusOK, gin.H{"code": "SUCCESS"})
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/api/workflow/refresh-subscription-and-reselect", bytes.NewBufferString(`{"subscriptionId":3}`))

--- a/service/server/router/index.go
+++ b/service/server/router/index.go
@@ -128,19 +128,7 @@ func nocache(c *gin.Context) {
 	c.Header("Expires", "0")
 }
 
-func Run() error {
-	engine := gin.New()
-	//ginpprof.Wrap(engine)
-	engine.Use(gin.Recovery())
-	corsConfig := cors.DefaultConfig()
-	corsConfig.AllowAllOrigins = true
-	corsConfig.AllowMethods = []string{
-		"GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS", "HEAD",
-	}
-	corsConfig.AllowWebSockets = true
-	corsConfig.AllowCredentials = true
-	corsConfig.AddAllowHeaders("Authorization", common.RequestIdHeader)
-	engine.Use(cors.New(corsConfig))
+func RegisterRoutes(engine *gin.Engine) {
 	noAuth := engine.Group("api",
 		nocache,
 		reqCache.ReqCache,
@@ -182,6 +170,7 @@ func Run() error {
 		auth.DELETE("gfwList", controller.DeleteGFWList)
 		auth.PUT("subscription", controller.PutSubscription)
 		auth.PATCH("subscription", controller.PatchSubscription)
+		auth.POST("workflow/refresh-subscription-and-reselect", controller.PostRefreshSubscriptionAndReselect)
 		auth.GET("ports", controller.GetPorts)
 		auth.PUT("ports", controller.PutPorts)
 		//auth.PUT("account", controller.PutAccount)
@@ -201,6 +190,22 @@ func Run() error {
 		auth.PUT("domainsExcluded", controller.PutDomainsExcluded)
 		auth.PUT("tproxyWhiteIpGroups", controller.PutTproxyWhiteIpGroups)
 	}
+}
+
+func Run() error {
+	engine := gin.New()
+	//ginpprof.Wrap(engine)
+	engine.Use(gin.Recovery())
+	corsConfig := cors.DefaultConfig()
+	corsConfig.AllowAllOrigins = true
+	corsConfig.AllowMethods = []string{
+		"GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS", "HEAD",
+	}
+	corsConfig.AllowWebSockets = true
+	corsConfig.AllowCredentials = true
+	corsConfig.AddAllowHeaders("Authorization", common.RequestIdHeader)
+	engine.Use(cors.New(corsConfig))
+	RegisterRoutes(engine)
 
 	ServeGUI(engine)
 

--- a/service/server/router/index_test.go
+++ b/service/server/router/index_test.go
@@ -1,0 +1,22 @@
+package router
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestRegisterRoutesIncludesWorkflowEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+
+	RegisterRoutes(engine)
+
+	for _, route := range engine.Routes() {
+		if route.Method == http.MethodPost && route.Path == "/api/workflow/refresh-subscription-and-reselect" {
+			return
+		}
+	}
+	t.Fatal("workflow route not registered")
+}

--- a/service/server/router/web/index.html
+++ b/service/server/router/web/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>v2rayA</title>
+</head>
+<body></body>
+</html>

--- a/service/server/service/workflow.go
+++ b/service/server/service/workflow.go
@@ -1,0 +1,88 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/v2rayA/v2rayA/db/configure"
+)
+
+var (
+	getWorkflowSetting          = GetSetting
+	updateWorkflowSetting       = UpdateSetting
+	updateWorkflowSubscription  = UpdateSubscription
+	getWorkflowSubscription     = configure.GetSubscription
+	getWorkflowSubscriptionsLen = configure.GetLenSubscriptions
+	getWorkflowConnectedServers = configure.GetConnectedServers
+	disconnectWorkflowServer    = Disconnect
+	connectWorkflowServer       = Connect
+	isSupportedWorkflowServer   = IsSupported
+)
+
+func RefreshSubscriptionAndReselect(index int) error {
+	if index < 0 || index >= getWorkflowSubscriptionsLen() || getWorkflowSubscription(index) == nil {
+		return fmt.Errorf("bad request: ID exceed range")
+	}
+
+	setting := getWorkflowSetting()
+	nextSetting := *setting
+	nextSetting.Transparent = configure.TransparentClose
+	if err := updateWorkflowSetting(&nextSetting); err != nil {
+		return err
+	}
+	if err := updateWorkflowSubscription(index, false); err != nil {
+		return err
+	}
+	if err := disconnectSubscriptionServers(index); err != nil {
+		return err
+	}
+	if err := connectFirstAvailableSubscriptionServer(index); err != nil {
+		return err
+	}
+	return nil
+}
+
+func disconnectSubscriptionServers(index int) error {
+	for _, which := range getWorkflowConnectedServers().Get() {
+		if which.TYPE != configure.SubscriptionServerType || which.Sub != index {
+			continue
+		}
+		if err := disconnectWorkflowServer(*which, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func connectFirstAvailableSubscriptionServer(index int) error {
+	subscription := getWorkflowSubscription(index)
+	if subscription == nil {
+		return fmt.Errorf("bad request: ID exceed range")
+	}
+
+	var lastErr error
+	which := configure.Which{
+		TYPE:     configure.SubscriptionServerType,
+		Sub:      index,
+		Outbound: "proxy",
+	}
+	for i := range subscription.Servers {
+		which.ID = i + 1
+		supported, err := isSupportedWorkflowServer(which)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if !supported {
+			continue
+		}
+		if err := connectWorkflowServer(&which); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+	}
+	if lastErr != nil {
+		return fmt.Errorf("no connectable server found in subscription: %w", lastErr)
+	}
+	return fmt.Errorf("no connectable server found in subscription")
+}

--- a/service/server/service/workflow_test.go
+++ b/service/server/service/workflow_test.go
@@ -1,0 +1,136 @@
+package service
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/v2rayA/v2rayA/db/configure"
+)
+
+func TestRefreshSubscriptionAndReselectSequence(t *testing.T) {
+	originalGetSetting := getWorkflowSetting
+	originalUpdateSetting := updateWorkflowSetting
+	originalUpdateSubscription := updateWorkflowSubscription
+	originalGetSubscription := getWorkflowSubscription
+	originalGetSubscriptionsLen := getWorkflowSubscriptionsLen
+	originalGetConnectedServers := getWorkflowConnectedServers
+	originalDisconnectServer := disconnectWorkflowServer
+	originalConnectServer := connectWorkflowServer
+	originalIsSupported := isSupportedWorkflowServer
+	t.Cleanup(func() {
+		getWorkflowSetting = originalGetSetting
+		updateWorkflowSetting = originalUpdateSetting
+		updateWorkflowSubscription = originalUpdateSubscription
+		getWorkflowSubscription = originalGetSubscription
+		getWorkflowSubscriptionsLen = originalGetSubscriptionsLen
+		getWorkflowConnectedServers = originalGetConnectedServers
+		disconnectWorkflowServer = originalDisconnectServer
+		connectWorkflowServer = originalConnectServer
+		isSupportedWorkflowServer = originalIsSupported
+	})
+
+	var calls []string
+	getWorkflowSubscriptionsLen = func() int { return 1 }
+	getWorkflowSubscription = func(index int) *configure.SubscriptionRaw {
+		return &configure.SubscriptionRaw{
+			Servers: []configure.ServerRaw{{}, {}},
+		}
+	}
+	getWorkflowSetting = func() *configure.Setting {
+		return &configure.Setting{Transparent: configure.TransparentProxy}
+	}
+	updateWorkflowSetting = func(setting *configure.Setting) error {
+		if setting.Transparent != configure.TransparentClose {
+			t.Fatalf("expected transparent mode close, got %q", setting.Transparent)
+		}
+		calls = append(calls, "setting")
+		return nil
+	}
+	updateWorkflowSubscription = func(index int, disconnectIfNecessary bool) error {
+		if index != 0 {
+			t.Fatalf("unexpected subscription index: %d", index)
+		}
+		if disconnectIfNecessary {
+			t.Fatalf("unexpected disconnectIfNecessary=true")
+		}
+		calls = append(calls, "subscription")
+		return nil
+	}
+	getWorkflowConnectedServers = func() *configure.Whiches {
+		return configure.NewWhiches([]*configure.Which{
+			{TYPE: configure.SubscriptionServerType, Sub: 0, ID: 2, Outbound: "proxy"},
+			{TYPE: configure.ServerType, ID: 1, Outbound: "proxy"},
+		})
+	}
+	disconnectWorkflowServer = func(which configure.Which, clearOutbound bool) error {
+		if which.TYPE != configure.SubscriptionServerType || which.Sub != 0 || which.ID != 2 {
+			t.Fatalf("unexpected disconnect target: %#v", which)
+		}
+		if clearOutbound {
+			t.Fatalf("unexpected clearOutbound=true")
+		}
+		calls = append(calls, "disconnect")
+		return nil
+	}
+	isSupportedWorkflowServer = func(which configure.Which) (bool, error) {
+		return true, nil
+	}
+	connectWorkflowServer = func(which *configure.Which) error {
+		if which.ID != 1 {
+			t.Fatalf("expected first server to be selected, got %d", which.ID)
+		}
+		calls = append(calls, "connect")
+		return nil
+	}
+
+	if err := RefreshSubscriptionAndReselect(0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []string{"setting", "subscription", "disconnect", "connect"}
+	if !reflect.DeepEqual(calls, expected) {
+		t.Fatalf("unexpected call sequence: %#v", calls)
+	}
+}
+
+func TestRefreshSubscriptionAndReselectNoConnectableServer(t *testing.T) {
+	originalGetSetting := getWorkflowSetting
+	originalUpdateSetting := updateWorkflowSetting
+	originalUpdateSubscription := updateWorkflowSubscription
+	originalGetSubscription := getWorkflowSubscription
+	originalGetSubscriptionsLen := getWorkflowSubscriptionsLen
+	originalGetConnectedServers := getWorkflowConnectedServers
+	originalDisconnectServer := disconnectWorkflowServer
+	originalConnectServer := connectWorkflowServer
+	originalIsSupported := isSupportedWorkflowServer
+	t.Cleanup(func() {
+		getWorkflowSetting = originalGetSetting
+		updateWorkflowSetting = originalUpdateSetting
+		updateWorkflowSubscription = originalUpdateSubscription
+		getWorkflowSubscription = originalGetSubscription
+		getWorkflowSubscriptionsLen = originalGetSubscriptionsLen
+		getWorkflowConnectedServers = originalGetConnectedServers
+		disconnectWorkflowServer = originalDisconnectServer
+		connectWorkflowServer = originalConnectServer
+		isSupportedWorkflowServer = originalIsSupported
+	})
+
+	getWorkflowSubscriptionsLen = func() int { return 1 }
+	getWorkflowSubscription = func(index int) *configure.SubscriptionRaw {
+		return &configure.SubscriptionRaw{
+			Servers: []configure.ServerRaw{{}},
+		}
+	}
+	getWorkflowSetting = func() *configure.Setting { return &configure.Setting{} }
+	updateWorkflowSetting = func(setting *configure.Setting) error { return nil }
+	updateWorkflowSubscription = func(index int, disconnectIfNecessary bool) error { return nil }
+	getWorkflowConnectedServers = func() *configure.Whiches { return nil }
+	isSupportedWorkflowServer = func(which configure.Which) (bool, error) { return true, nil }
+	connectWorkflowServer = func(which *configure.Which) error { return errors.New("dial failed") }
+	disconnectWorkflowServer = func(which configure.Which, clearOutbound bool) error { return nil }
+
+	if err := RefreshSubscriptionAndReselect(0); err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- add an authenticated workflow endpoint at 
- implement a service workflow that closes transparent mode, refreshes a target subscription, disconnects existing subscription nodes, and reconnects the first connectable node
- add focused controller/service/router tests and make test startup tolerate Go  flags

## Testing
- PATH=/home/pdfreader/.local/go122/go/bin:/home/pdfreader/.codex/tmp/arg0/codex-arg0OsFgyB:/home/pdfreader/.local/share/pnpm/global/5/.pnpm/@openai+codex@0.111.0-linux-x64/node_modules/@openai/codex/vendor/x86_64-unknown-linux-musl/path:/home/pdfreader/.bun/bin:/home/pdfreader/.bun/bin:/home/pdfreader/.opencode/bin:/home/pdfreader/.local/share/pnpm:/home/pdfreader/.nvm/versions/node/v22.21.1/bin:/home/pdfreader/.opencode/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/pdfreader/.local/bin:/home/pdfreader/.local/bin:/home/pdfreader/.local/bin:/home/pdfreader/.local/bin go test ./server/controller ./server/service ./server/router
