### PR TITLE
fix(bug): Memory leak when connection fails

### DIFF
--- a/service/core/v2ray/api.go
+++ b/service/core/v2ray/api.go
@@ -105,6 +105,8 @@ func ObservatoryProducer(apiPort int, observatoryTags []string) (closeFunc func(
 				)
 				if err != nil {
 					log.Warn("ObservatoryProducer: did not connect: %v", err)
+					// cancel the context to avoid leaking resources
+					cancel()
 					continue nextLoop
 				}
 				defer c.Close()


### PR DESCRIPTION
This pull request introduces a small but important resource management improvement to the `ObservatoryProducer` function. Now, when a connection attempt fails, the context is explicitly cancelled to avoid leaking resources.

* Resource management:
  * In `service/core/v2ray/api.go`, added a call to `cancel()` when a connection fails in the `ObservatoryProducer` function to prevent resource leaks.