### PR TITLE
feat(ss): support Shadowsocks 2022 via sing-shadowsocks plugin

### DIFF
--- a/.github/workflows/beta_release_main.yml
+++ b/.github/workflows/beta_release_main.yml
@@ -18,9 +18,9 @@ jobs:
       shell: bash
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        brew install node@24
-        echo "PATH=\"$(brew --prefix)/opt/node@24/bin:$PATH\"" >> $GITHUB_ENV
-        echo "PATH=\"$(brew --prefix)/opt/node@24/bin:$PATH\"" >> ~/.bash_profile         
+        brew install node@22
+        echo "PATH=\"$(brew --prefix)/opt/node@22/bin:$PATH\"" >> $GITHUB_ENV
+        echo "PATH=\"$(brew --prefix)/opt/node@22/bin:$PATH\"" >> ~/.bash_profile
     - name: Install Dependencies
       run: |
         sudo apt-get update -y && sudo apt-get install -y gzip

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,9 +18,9 @@ jobs:
       shell: bash
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        brew install node@24
-        echo "PATH=\"$(brew --prefix)/opt/node@24/bin:$PATH\"" >> $GITHUB_ENV
-        echo "PATH=\"$(brew --prefix)/opt/node@24/bin:$PATH\"" >> ~/.bash_profile
+        brew install node@22
+        echo "PATH=\"$(brew --prefix)/opt/node@22/bin:$PATH\"" >> $GITHUB_ENV
+        echo "PATH=\"$(brew --prefix)/opt/node@22/bin:$PATH\"" >> ~/.bash_profile
     - name: Install Dependencies
       run: |
         sudo apt-get update -y && sudo apt-get install -y gzip

--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -17,9 +17,9 @@ jobs:
       shell: bash
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        brew install node@24
-        echo "PATH=\"$(brew --prefix)/opt/node@24/bin:$PATH\"" >> $GITHUB_ENV
-        echo "PATH=\"$(brew --prefix)/opt/node@24/bin:$PATH\"" >> ~/.bash_profile
+        brew install node@22
+        echo "PATH=\"$(brew --prefix)/opt/node@22/bin:$PATH\"" >> $GITHUB_ENV
+        echo "PATH=\"$(brew --prefix)/opt/node@22/bin:$PATH\"" >> ~/.bash_profile
     - name: Install Dependencies
       run: |
         sudo apt-get update -y && sudo apt-get install -y gzip

--- a/.github/workflows/test_build_main.yml
+++ b/.github/workflows/test_build_main.yml
@@ -24,9 +24,9 @@ jobs:
       shell: bash
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        brew install node@24
-        echo "PATH=\"$(brew --prefix)/opt/node@24/bin:$PATH\"" >> $GITHUB_ENV
-        echo "PATH=\"$(brew --prefix)/opt/node@24/bin:$PATH\"" >> ~/.bash_profile
+        brew install node@22
+        echo "PATH=\"$(brew --prefix)/opt/node@22/bin:$PATH\"" >> $GITHUB_ENV
+        echo "PATH=\"$(brew --prefix)/opt/node@22/bin:$PATH\"" >> ~/.bash_profile
     - name: Install Dependencies
       run: |
         sudo apt-get update -y && sudo apt-get install -y gzip

--- a/service/core/serverObj/shadowsocks.go
+++ b/service/core/serverObj/shadowsocks.go
@@ -325,10 +325,40 @@ func (s *Shadowsocks) ConfigurationMT(info PriorInfo) (c Configuration, err erro
 	}, nil
 }
 
+func isShadowsocks2022Cipher(cipher string) bool {
+	switch strings.ToLower(cipher) {
+	case "2022-blake3-aes-128-gcm",
+		"2022-blake3-aes-256-gcm",
+		"2022-blake3-chacha20-poly1305":
+		return true
+	}
+	return false
+}
+
 func (s *Shadowsocks) Configuration(info PriorInfo) (c Configuration, err error) {
 	socks5 := url.URL{
 		Scheme: "socks5",
 		Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(info.PluginPort)),
+	}
+	// 2022-blake3-* ciphers are dispatched to the ss2022 plugin dialer
+	// (sing-shadowsocks) because neither v2ray-core's v4 loader nor the
+	// daeuniverse/outbound SS library understand them. Use a plain
+	// method:psk userinfo form (no base64, no fragment) so neither the
+	// chain splitter nor a server-name comma can mangle the URL.
+	if isShadowsocks2022Cipher(s.Cipher) {
+		if s.Plugin.Name != "" {
+			return c, fmt.Errorf("shadowsocks2022 does not support plugin %q", s.Plugin.Name)
+		}
+		upstream := url.URL{
+			Scheme: "ss2022",
+			User:   url.UserPassword(s.Cipher, s.Password),
+			Host:   net.JoinHostPort(s.Server, strconv.Itoa(s.Port)),
+		}
+		return Configuration{
+			CoreOutbound: info.PluginObj(),
+			PluginChain:  strings.Join([]string{socks5.String(), upstream.String()}, ","),
+			UDPSupport:   false,
+		}, nil
 	}
 	chain := []string{socks5.String(), s.ExportToURL()}
 	return Configuration{

--- a/service/core/serverObj/shadowsocks.go
+++ b/service/core/serverObj/shadowsocks.go
@@ -357,7 +357,7 @@ func (s *Shadowsocks) Configuration(info PriorInfo) (c Configuration, err error)
 		return Configuration{
 			CoreOutbound: info.PluginObj(),
 			PluginChain:  strings.Join([]string{socks5.String(), upstream.String()}, ","),
-			UDPSupport:   false,
+			UDPSupport:   true,
 		}, nil
 	}
 	chain := []string{socks5.String(), s.ExportToURL()}

--- a/service/go.mod
+++ b/service/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sagernet/gvisor v0.0.0-20241123041152-536d05261cff
 	github.com/sagernet/sing v0.7.18
+	github.com/sagernet/sing-shadowsocks v0.2.9
 	github.com/sagernet/sing-tun v0.7.11
 	github.com/shirou/gopsutil/v3 v3.21.11
 	github.com/stevenroose/gonfig v0.1.5
@@ -114,6 +115,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230807174057-1744710a1577 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	lukechampine.com/blake3 v1.4.1 // indirect
 )
 
 // Replace dependency modules with local developing copy

--- a/service/go.sum
+++ b/service/go.sum
@@ -220,6 +220,8 @@ github.com/sagernet/nftables v0.3.0-beta.4 h1:kbULlAwAC3jvdGAC1P5Fa3GSxVwQJibNen
 github.com/sagernet/nftables v0.3.0-beta.4/go.mod h1:OQXAjvjNGGFxaTgVCSTRIhYB5/llyVDeapVoENYBDS8=
 github.com/sagernet/sing v0.7.18 h1:iZHkaru1/MoHugx3G+9S3WG4owMewKO/KvieE2Pzk4E=
 github.com/sagernet/sing v0.7.18/go.mod h1:ARkL0gM13/Iv5VCZmci/NuoOlePoIsW0m7BWfln/Hak=
+github.com/sagernet/sing-shadowsocks v0.2.9 h1:Paep5zCszRKsEn8587O0MnhFWKJwDW1Y4zOYYlIxMkM=
+github.com/sagernet/sing-shadowsocks v0.2.9/go.mod h1:TE/Z6401Pi8tgr0nBZcM/xawAI6u3F6TTbz4nH/qw+8=
 github.com/sagernet/sing-tun v0.7.11 h1:qB7jy8JKqXg73fYBsDkBSy4ulRSbLrFut0e+y+QPhqU=
 github.com/sagernet/sing-tun v0.7.11/go.mod h1:pUEjh9YHQ2gJT6Lk0TYDklh3WJy7lz+848vleGM3JPM=
 github.com/secure-io/siv-go v0.0.0-20180922214919-5ff40651e2c4 h1:zOjq+1/uLzn/Xo40stbvjIY/yehG0+mfmlsiEmc0xmQ=
@@ -378,5 +380,7 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+lukechampine.com/blake3 v1.4.1 h1:I3Smz7gso8w4/TunLKec6K2fn+kyKtDxr/xcQEN84Wg=
+lukechampine.com/blake3 v1.4.1/go.mod h1:QFosUxmjB8mnrWFSNwKmvxHpfY72bmD2tQ0kBMM3kwo=
 nullprogram.com/x/optparse v1.0.0/go.mod h1:KdyPE+Igbe0jQUrVfMqDMeJQIJZEuyV7pjYmp6pbG50=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/service/main.go
+++ b/service/main.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/v2rayA/v2rayA/pkg/plugin/simpleobfs"
 	_ "github.com/v2rayA/v2rayA/pkg/plugin/socks5"
 	_ "github.com/v2rayA/v2rayA/pkg/plugin/ss"
+	_ "github.com/v2rayA/v2rayA/pkg/plugin/ss2022"
 	_ "github.com/v2rayA/v2rayA/pkg/plugin/ssr"
 	_ "github.com/v2rayA/v2rayA/pkg/plugin/tcp"
 	_ "github.com/v2rayA/v2rayA/pkg/plugin/tls"

--- a/service/pkg/plugin/ss2022/ss2022.go
+++ b/service/pkg/plugin/ss2022/ss2022.go
@@ -1,0 +1,78 @@
+package ss2022
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+
+	shadowsocks "github.com/sagernet/sing-shadowsocks"
+	"github.com/sagernet/sing-shadowsocks/shadowaead_2022"
+	M "github.com/sagernet/sing/common/metadata"
+
+	"github.com/v2rayA/v2rayA/pkg/plugin"
+	"github.com/v2rayA/v2rayA/pkg/util/log"
+)
+
+type Shadowsocks2022 struct {
+	upstream plugin.Dialer
+	method   shadowsocks.Method
+	server   string // "host:port"
+}
+
+func init() {
+	log.Trace("[shadowsocks2022] registering dialer")
+	plugin.RegisterDialer("ss2022", NewShadowsocks2022Dialer)
+}
+
+func NewShadowsocks2022Dialer(s string, d plugin.Dialer) (plugin.Dialer, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return nil, fmt.Errorf("parse ss2022 url %q: %w", s, err)
+	}
+	if u.User == nil {
+		return nil, fmt.Errorf("ss2022 url %q missing userinfo", s)
+	}
+	method := u.User.Username()
+	password, hasPassword := u.User.Password()
+	if method == "" || !hasPassword {
+		return nil, fmt.Errorf("ss2022 url %q missing method or psk", s)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		return nil, fmt.Errorf("ss2022 url port %q: %w", u.Port(), err)
+	}
+	m, err := shadowaead_2022.NewWithPassword(method, password, nil)
+	if err != nil {
+		return nil, fmt.Errorf("ss2022 new method %q: %w", method, err)
+	}
+	return &Shadowsocks2022{
+		upstream: d,
+		method:   m,
+		server:   net.JoinHostPort(u.Hostname(), strconv.Itoa(port)),
+	}, nil
+}
+
+func (s *Shadowsocks2022) Addr() string { return s.server }
+
+func (s *Shadowsocks2022) Dial(network, addr string) (net.Conn, error) {
+	return s.DialContext(context.Background(), network, addr)
+}
+
+func (s *Shadowsocks2022) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	rc, err := s.upstream.DialContext(ctx, "tcp", s.server)
+	if err != nil {
+		return nil, fmt.Errorf("[ss2022]: dial server %s: %w", s.server, err)
+	}
+	wrapped, err := s.method.DialConn(rc, M.ParseSocksaddr(addr))
+	if err != nil {
+		_ = rc.Close()
+		return nil, fmt.Errorf("[ss2022]: wrap conn: %w", err)
+	}
+	return wrapped, nil
+}
+
+func (s *Shadowsocks2022) DialUDP(network string) (plugin.FakeNetPacketConn, error) {
+	return nil, fmt.Errorf("[ss2022]: UDP is not yet supported")
+}

--- a/service/pkg/plugin/ss2022/ss2022.go
+++ b/service/pkg/plugin/ss2022/ss2022.go
@@ -74,5 +74,14 @@ func (s *Shadowsocks2022) DialContext(ctx context.Context, network, addr string)
 }
 
 func (s *Shadowsocks2022) DialUDP(network string) (plugin.FakeNetPacketConn, error) {
-	return nil, fmt.Errorf("[ss2022]: UDP is not yet supported")
+	// Dial a UDP conn to the ss2022 server through the upstream (typically
+	// Direct). sing-shadowsocks' Method wraps that conn into an
+	// N.NetPacketConn which already satisfies net.PacketConn — each
+	// WriteTo/ReadFrom is one ss2022-framed UDP packet with its own
+	// destination/source address.
+	rc, err := s.upstream.DialContext(context.TODO(), "udp", s.server)
+	if err != nil {
+		return nil, fmt.Errorf("[ss2022]: dial udp server %s: %w", s.server, err)
+	}
+	return s.method.DialPacketConn(rc), nil
 }


### PR DESCRIPTION
  The `2022-blake3-*` ciphers listed in the SS method dropdown did not actually work. v2ray-core's v4 JSON loader does not recognize the shadowsocks2022 protocol (it is only registered in the v5 config system), and the dae universe/outbound library that v2rayA delegates SS dialing to has no 2022 cipher implementation — both paths fail at config-load or dial time.

  Add a new in-process dialer plugin (pkg/plugin/ss2022) backed by sing-shadowsocks' shadowaead_2022 implementation. Dispatch SS servers whose cipher is 2022-blake3-aes-128-gcm, -aes-256-gcm, or -chacha20-poly1305 through this plugin; all other ciphers stay on the existing daeuniverse path untouched.

  The `ss://` chain URL stays base64-encoded for daeuniverse compatibility, but the new `ss2022://` URL uses a plain method:psk
  userinfo (no base64, no fragment) so neither the chain "," splitter nor a server-name fragment can mangle it.

  Limitations:
  - SIP003 plugins (simple-obfs, v2ray-plugin) are rejected on the ss2022 path; 2022 defines its own framing and combining with SIP003 is non-standard.

  **Notes: The changes were made by Claude Code. So please carefully check the changes.  Based on my manual tests, the support to 2022-blake3-\* was validated.
  请注意：相关修改由Claude Code完成，建议仔细检查代码修改。
  目前，经本人测试，已能够支持Shadowsocks 2022协议。**