### PR TITLE
Add XHTTP raw passthrough support for downloadSettings

### DIFF
--- a/service/core/coreObj/coreObj.go
+++ b/service/core/coreObj/coreObj.go
@@ -1,5 +1,9 @@
 package coreObj
 
+import (
+	jsoniter "github.com/json-iterator/go"
+)
+
 type APIObject struct {
 	Tag      string   `json:"tag"`
 	Services []string `json:"services"`
@@ -255,10 +259,32 @@ type QuicSettings struct {
 	Security string    `json:"security"`
 }
 type XHTTPSettings struct {
-	Path string `json:"path"`
-	Host string `json:"host,omitempty"`
-	Mode string `json:"mode,omitempty"`
+	Path        string                 `json:"path"`
+	Host        string                 `json:"host,omitempty"`
+	Mode        string                 `json:"mode,omitempty"`
+	Passthrough map[string]interface{} `json:"-"`
 }
+
+func (x XHTTPSettings) MarshalJSON() ([]byte, error) {
+	m := make(map[string]interface{})
+	m["path"] = x.Path
+	if x.Host != "" {
+		m["host"] = x.Host
+	}
+	if x.Mode != "" {
+		m["mode"] = x.Mode
+	}
+	for k, v := range x.Passthrough {
+		switch k {
+		case "path", "host", "mode":
+			continue
+		default:
+			m[k] = v
+		}
+	}
+	return jsoniter.Marshal(m)
+}
+
 type Hosts map[string][]string
 
 type DNS struct {

--- a/service/core/serverObj/v2ray.go
+++ b/service/core/serverObj/v2ray.go
@@ -53,8 +53,26 @@ type V2Ray struct {
 	Key           string `json:"key,omitempty"`
 	QuicSecurity  string `json:"quicSecurity"`
 	XHTTPMode     string `json:"xhttpMode,omitempty"`
+	XHTTPRawJson  string `json:"xhttpRawJson,omitempty"`
 	V             string `json:"v"`
 	Protocol      string `json:"protocol"`
+}
+
+func parseXHTTPRawJson(raw string) (map[string]interface{}, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var m map[string]interface{}
+	if err := jsoniter.Unmarshal([]byte(raw), &m); err != nil {
+		return nil, err
+	}
+	if m == nil {
+		m = make(map[string]interface{})
+	}
+	delete(m, "path")
+	delete(m, "host")
+	delete(m, "mode")
+	return m, nil
 }
 
 func NewV2Ray(link string) (ServerObj, error) {
@@ -120,6 +138,7 @@ func ParseVlessURL(vless string) (data *V2Ray, err error) {
 		if data.XHTTPMode == "" {
 			data.XHTTPMode = "auto"
 		}
+		data.XHTTPRawJson = u.Query().Get("xhttpRawJson")
 	}
 	return data, nil
 }
@@ -274,14 +293,14 @@ func (v *V2Ray) Configuration(info PriorInfo) (c Configuration, err error) {
 					},
 				},
 			}
-		// if network == "tcp" {
-		// 	tcpSetting := coreObj.TCPSettings{
-		// 		Header: coreObj.TCPHeader{
-		// 			Type: "none",
-		// 		},
-		// 	}
-		// 	core.StreamSettings.TCPSettings = &tcpSetting
-		// }
+			// if network == "tcp" {
+			// 	tcpSetting := coreObj.TCPSettings{
+			// 		Header: coreObj.TCPHeader{
+			// 			Type: "none",
+			// 		},
+			// 	}
+			// 	core.StreamSettings.TCPSettings = &tcpSetting
+			// }
 		}
 		// 根据传输协议(network)修改streamSettings
 		//TODO: QUIC
@@ -377,17 +396,15 @@ func (v *V2Ray) Configuration(info PriorInfo) (c Configuration, err error) {
 				Security: v.QuicSecurity,
 			}
 		case "xhttp":
-			if v.Host != "" {
-				core.StreamSettings.XHTTPSettings = &coreObj.XHTTPSettings{
-					Path: v.Path,
-					Host: v.Host,
-					Mode: v.XHTTPMode,
-				}
-			} else {
-				core.StreamSettings.XHTTPSettings = &coreObj.XHTTPSettings{
-					Path: v.Path,
-					Mode: v.XHTTPMode,
-				}
+			passthrough, err := parseXHTTPRawJson(v.XHTTPRawJson)
+			if err != nil {
+				return Configuration{}, fmt.Errorf("invalid xhttpRawJson: %w", err)
+			}
+			core.StreamSettings.XHTTPSettings = &coreObj.XHTTPSettings{
+				Path:        v.Path,
+				Host:        v.Host,
+				Mode:        v.XHTTPMode,
+				Passthrough: passthrough,
 			}
 		default:
 			return Configuration{}, fmt.Errorf("unexpected transport type: %v", v.Net)
@@ -486,6 +503,7 @@ func (v *V2Ray) ExportToURL() string {
 			setValue(&query, "path", v.Path)
 			setValue(&query, "host", v.Host)
 			setValue(&query, "xhttpMode", v.XHTTPMode)
+			setValue(&query, "xhttpRawJson", v.XHTTPRawJson)
 		}
 		if v.TLS != "none" {
 			setValue(&query, "flow", v.Flow)

--- a/service/core/serverObj/v2ray_test.go
+++ b/service/core/serverObj/v2ray_test.go
@@ -1,0 +1,146 @@
+package serverObj
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+)
+
+func loadXHTTPFixture(t *testing.T, name string) map[string]interface{} {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "tmp", "test-configs", name)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", path, err)
+	}
+	var m map[string]interface{}
+	if err = jsoniter.Unmarshal(b, &m); err != nil {
+		t.Fatalf("failed to unmarshal fixture %s: %v", path, err)
+	}
+	return m
+}
+
+func marshalJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := jsoniter.Marshal(v)
+	if err != nil {
+		t.Fatalf("failed to marshal json: %v", err)
+	}
+	return string(b)
+}
+
+func assertJSONEqual(t *testing.T, got string, want interface{}) {
+	t.Helper()
+	var gotValue interface{}
+	if err := jsoniter.Unmarshal([]byte(got), &gotValue); err != nil {
+		t.Fatalf("failed to unmarshal got json: %v", err)
+	}
+	wantJSON := marshalJSON(t, want)
+	var wantValue interface{}
+	if err := jsoniter.Unmarshal([]byte(wantJSON), &wantValue); err != nil {
+		t.Fatalf("failed to unmarshal want json: %v", err)
+	}
+	if !reflect.DeepEqual(gotValue, wantValue) {
+		t.Fatalf("unexpected json\nwant: %s\ngot:  %s", wantJSON, got)
+	}
+}
+
+func passthroughJSONFromXHTTPFixture(t *testing.T, name string) string {
+	t.Helper()
+	m := loadXHTTPFixture(t, name)
+	delete(m, "path")
+	delete(m, "host")
+	delete(m, "mode")
+	return marshalJSON(t, m)
+}
+
+func configuredXHTTPSettingsJSON(t *testing.T, v *V2Ray) string {
+	t.Helper()
+	cfg, err := v.Configuration(PriorInfo{Tag: "proxy"})
+	if err != nil {
+		t.Fatalf("failed to generate configuration: %v", err)
+	}
+	return marshalJSON(t, cfg.CoreOutbound.StreamSettings.XHTTPSettings)
+}
+
+func TestV2RayXHTTPConfigurationWithoutRawExtras(t *testing.T) {
+	v := &V2Ray{
+		Add:       "proxy.example.com",
+		Port:      "443",
+		ID:        "11111111-1111-1111-1111-111111111111",
+		Net:       "xhttp",
+		Path:      "/",
+		Host:      "proxy.example.com",
+		XHTTPMode: "auto",
+		TLS:       "none",
+		Protocol:  "vless",
+	}
+
+	got := configuredXHTTPSettingsJSON(t, v)
+	want := map[string]interface{}{
+		"path": "/",
+		"host": "proxy.example.com",
+		"mode": "auto",
+	}
+	assertJSONEqual(t, got, want)
+}
+
+func TestV2RayXHTTPConfigurationWithDownloadSettings(t *testing.T) {
+	v := &V2Ray{
+		Add:          "proxy.example.com",
+		Port:         "443",
+		ID:           "11111111-1111-1111-1111-111111111111",
+		Net:          "xhttp",
+		Path:         "/",
+		Host:         "proxy.example.com",
+		XHTTPMode:    "packet-up",
+		XHTTPRawJson: passthroughJSONFromXHTTPFixture(t, "xhttp-settings-with-downloads.json"),
+		TLS:          "reality",
+		SNI:          "proxy.example.com",
+		PublicKey:    "FAKE_PUBLIC_KEY",
+		ShortId:      "0123456789ab",
+		SpiderX:      "/",
+		Fingerprint:  "chrome",
+		Protocol:     "vless",
+	}
+
+	got := configuredXHTTPSettingsJSON(t, v)
+	assertJSONEqual(t, got, loadXHTTPFixture(t, "xhttp-settings-with-downloads.json"))
+}
+
+func TestV2RayXHTTPRoundtripPreservesRawExtras(t *testing.T) {
+	rawJSON := passthroughJSONFromXHTTPFixture(t, "xhttp-settings-with-downloads.json")
+	original := &V2Ray{
+		Ps:           "xhttp-node",
+		Add:          "proxy.example.com",
+		Port:         "443",
+		ID:           "11111111-1111-1111-1111-111111111111",
+		Net:          "xhttp",
+		Path:         "/",
+		Host:         "proxy.example.com",
+		XHTTPMode:    "packet-up",
+		XHTTPRawJson: rawJSON,
+		TLS:          "reality",
+		SNI:          "proxy.example.com",
+		PublicKey:    "FAKE_PUBLIC_KEY",
+		ShortId:      "0123456789ab",
+		SpiderX:      "/",
+		Fingerprint:  "chrome",
+		Protocol:     "vless",
+	}
+
+	link := original.ExportToURL()
+	parsedObj, err := ParseVlessURL(link)
+	if err != nil {
+		t.Fatalf("failed to parse exported url: %v", err)
+	}
+	if parsedObj.XHTTPRawJson != rawJSON {
+		t.Fatalf("xhttpRawJson changed after roundtrip\nwant: %s\ngot:  %s", rawJSON, parsedObj.XHTTPRawJson)
+	}
+
+	got := configuredXHTTPSettingsJSON(t, parsedObj)
+	assertJSONEqual(t, got, loadXHTTPFixture(t, "xhttp-settings-with-downloads.json"))
+}

--- a/tmp/test-configs/xhttp-settings-no-downloads.json
+++ b/tmp/test-configs/xhttp-settings-no-downloads.json
@@ -1,0 +1,8 @@
+{
+  "host": "",
+  "mode": "auto",
+  "path": "/",
+  "scMaxConcurrentPosts": 10,
+  "scMaxEachPostBytes": 1000000,
+  "scMinPostsIntervalMs": "30"
+}

--- a/tmp/test-configs/xhttp-settings-with-downloads.json
+++ b/tmp/test-configs/xhttp-settings-with-downloads.json
@@ -1,0 +1,56 @@
+{
+  "extra": {
+    "downloadSettings": {
+      "address": "download.example.com",
+      "network": "xhttp",
+      "port": 443,
+      "realitySettings": {
+        "allowInsecure": false,
+        "fingerprint": "chrome",
+        "publicKey": "FAKE_PUBLIC_KEY",
+        "serverName": "download.example.com",
+        "shortId": "0123456789ab",
+        "show": false,
+        "spiderX": "/"
+      },
+      "security": "reality",
+      "xhttpSettings": {
+        "extra": {
+          "noGRPCHeader": true,
+          "scMaxEachPostBytes": "1000000-1000000",
+          "scMinPostsIntervalMs": "15-15",
+          "xPaddingBytes": "50-355",
+          "xmux": {
+            "cMaxReuseTimes": "0-0",
+            "hKeepAlivePeriod": 0,
+            "hMaxRequestTimes": "0-0",
+            "hMaxReusableSecs": "3180-3300",
+            "maxConcurrency": "0-0",
+            "maxConnections": "3-3"
+          }
+        },
+        "host": "download.example.com",
+        "mode": "packet-up",
+        "path": "/"
+      }
+    },
+    "noGRPCHeader": true,
+    "scMaxEachPostBytes": "150000-150000",
+    "scMinPostsIntervalMs": "15-15",
+    "xPaddingBytes": "50-355",
+    "xmux": {
+      "cMaxReuseTimes": "0-0",
+      "hKeepAlivePeriod": 0,
+      "hMaxRequestTimes": "0-0",
+      "hMaxReusableSecs": "3180-3300",
+      "maxConcurrency": "0-0",
+      "maxConnections": "1-1"
+    }
+  },
+  "host": "proxy.example.com",
+  "mode": "packet-up",
+  "path": "/",
+  "scMaxConcurrentPosts": 10,
+  "scMaxEachPostBytes": 1000000,
+  "scMinPostsIntervalMs": "30"
+}


### PR DESCRIPTION
## Summary

This change adds minimal passthrough support for XHTTP extra fields, including `xhttpSettings.extra.downloadSettings`, in v2rayA.

The goal is to preserve these fields during:

* import
* edit
* save
* config generation

without redesigning the current UI.

## What changed

* added `XHTTPRawJson` to the backend `V2Ray` model
* preserved `xhttpRawJson` through `ParseVlessURL` and `ExportToURL`
* extended `XHTTPSettings` with passthrough support
* merged opaque XHTTP extra fields into generated `xhttpSettings`
* added tests for:

  * normal XHTTP without raw extras
  * XHTTP with `extra.downloadSettings`
  * roundtrip preservation

## Notes

* existing XHTTP behavior for `path`, `host`, and `mode` is preserved
* unknown nested XHTTP extra fields are kept as opaque passthrough data
* test fixtures were sanitized and do not contain subscription-derived sensitive values

## Test result

Passed:

`cd service && go test ./core/serverObj/...`

There is also an existing unrelated failure in `go test ./core/...` under `core/specialMode/infra/TestReservedIP`, which is not introduced by this change.