### PR TITLE
feat: implement native Xray Hysteria2 with FinalMask support and robust protocol handling

### DIFF
--- a/.github/workflows/test_build_main.yml
+++ b/.github/workflows/test_build_main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat-hysteria2-finalmask
       - dependabot/*
     paths:
       - "**/*.go"

--- a/gui/src/assets/js/utils.js
+++ b/gui/src/assets/js/utils.js
@@ -114,7 +114,7 @@ function parseURL(u) {
         }
         s = seg[i].split("=");
         let key = s[0];
-        let val = decodeURIComponent(s[1]);
+        let val = s[1] ? decodeURIComponent(s[1]) : "";
         if (ret[key]) {
           if (Array.isArray(ret[key])) {
             ret[key].push(val);

--- a/gui/src/assets/js/utils.js
+++ b/gui/src/assets/js/utils.js
@@ -182,3 +182,10 @@ function sanitizeALPN(alpn) {
 }
 
 export { locateServer, handleResponse, parseURL, generateURL, toInt, sanitizeALPN };
+
+export function bracketIfIPv6(address) {
+  if (address.includes(":") && !address.startsWith("[") && !address.endsWith("]")) {
+    return "[" + address + "]";
+  }
+  return address;
+}

--- a/gui/src/components/modalServer.vue
+++ b/gui/src/components/modalServer.vue
@@ -92,15 +92,26 @@ v-show="v2ray.tls === 'tls' || v2ray.tls === 'reality'" label="uTLS fingerprint"
             <b-input v-model="v2ray.alpn" placeholder="h3,h2,http/1.1" expanded />
           </b-field>
           <b-field
+            v-if="v2ray.protocol === 'vless' && v2ray.tls !== 'none'"
+            label="Encryption"
+            label-position="on-border"
+          >
+            <b-input v-model="v2ray.scy" placeholder="none" expanded />
+          </b-field>
+          <b-field
 v-if="v2ray.protocol === 'vless' && v2ray.tls !== 'none'" ref="v2ray_flow" label="Flow"
             label-position="on-border"
           >
-            <b-input
+            <b-select
               ref="v2ray_flow"
               v-model="v2ray.flow"
               placeholder="Flow"
               expanded
-            />
+            >
+              <option value="none">{{ $t("setting.options.off") }}</option>
+              <option value="xtls-rprx-vision">xtls-rprx-vision</option>
+              <option value="xtls-rprx-vision-udp443">xtls-rprx-vision-udp443</option>
+            </b-select>
           </b-field>
           <b-field
             v-show="v2ray.tls === 'reality'"
@@ -1160,7 +1171,11 @@ export default {
     variant() {
       return localStorage["variant"]?.toLowerCase() || "v2ray";
     },
-    handleV2rayProtocolSwitch() { },
+    handleV2rayProtocolSwitch() {
+      if (this.v2ray.protocol === "vless" && this.v2ray.scy === "auto") {
+        this.v2ray.scy = "none";
+      }
+    },
     resolveURL(url) {
       if (url.toLowerCase().startsWith("vmess://")) {
         let obj = JSON.parse(
@@ -1187,13 +1202,14 @@ export default {
           path: u.params.path || u.params.serviceName || "",
           alpn: u.params.alpn || "",
           sni: u.params.sni || "",
-          tls: u.params.security || "none",
+          tls: u.params.security || u.params.tls || "none",
           quicSecurity: u.params.quicSecurity || "none",
           fp: u.params.fp || "",
           pbk: u.params.pbk || "",
           sid: u.params.sid || "",
           spx: u.params.spx || "",
           allowInsecure: u.params.allowInsecure || false,
+          scy: u.params.encryption || "none",
           key: u.params.key,
           xhttpMode: u.params.xhttpMode || "auto",
           xhttpRawJson: u.params.xhttpRawJson || "",
@@ -1423,7 +1439,6 @@ export default {
           // https://github.com/XTLS/Xray-core/discussions/716
           query = {
             type: srcObj.net,
-            flow: srcObj.flow || "",
             security: srcObj.tls,
             fp: srcObj.fp || "",
             path: srcObj.path,
@@ -1432,6 +1447,12 @@ export default {
             sni: srcObj.sni,
             allowInsecure: srcObj.allowInsecure,
           };
+          if (srcObj.flow && srcObj.flow !== "none") {
+            query.flow = srcObj.flow;
+          }
+          if (srcObj.scy && srcObj.scy !== "none") {
+            query.encryption = srcObj.scy;
+          }
           if (srcObj.alpn !== "") {
             query.alpn = srcObj.alpn;
           }
@@ -1695,7 +1716,7 @@ export default {
           }
           return generateURL(tmp);
         case "anytls":
-          let query = {};
+          query = {};
           if (srcObj.sni) {
             query.peer = srcObj.sni;
           }
@@ -1825,15 +1846,17 @@ export default {
           this.v2ray.allowInsecure === true ||
           this.v2ray.allowInsecure === "true"
         ) {
-          const { result } = await this.$buefy.dialog.confirm({
-            title: this.$t("InSecureConfirm.title"),
-            message: this.$t("InSecureConfirm.message"),
-            confirmText: this.$t("InSecureConfirm.confirm"),
-            cancelText: this.$t("InSecureConfirm.cancel"),
-            type: "is-danger",
-            hasIcon: true,
-            onConfirm: () => true,
-            onCancel: () => false,
+          let result = await new Promise((resolve) => {
+            this.$buefy.dialog.confirm({
+              title: this.$t("InSecureConfirm.title"),
+              message: this.$t("InSecureConfirm.message"),
+              confirmText: this.$t("InSecureConfirm.confirm"),
+              cancelText: this.$t("InSecureConfirm.cancel"),
+              type: "is-danger",
+              hasIcon: true,
+              onConfirm: () => resolve(true),
+              onCancel: () => resolve(false),
+            });
           });
           if (!result) {
             return;

--- a/gui/src/components/modalServer.vue
+++ b/gui/src/components/modalServer.vue
@@ -8,242 +8,245 @@
     <section ref="section" :class="{ 'modal-card-body': true }">
       <b-tabs v-model="tabChoice" class="block" type="is-boxed is-twitter" vertical>
         <b-tab-item label="V2RAY">
-          <b-field label="Protocol" label-position="on-border">
-            <b-select v-model="v2ray.protocol" expanded @input="handleV2rayProtocolSwitch">
-              <option value="vmess">VMESS</option>
-              <option value="vless">VLESS</option>
-            </b-select>
-          </b-field>
-          <b-field label="Name" label-position="on-border">
-            <b-input ref="v2ray_name" v-model="v2ray.ps" :placeholder="$t('configureServer.servername')" expanded />
-          </b-field>
-          <b-field label="Host" label-position="on-border">
-            <b-input ref="v2ray_add" required placeholder="IP / HOST" v-model="v2ray.add" expanded />
-          </b-field>
-          <b-field label="Port" label-position="on-border">
-            <b-input ref="v2ray_port" required :placeholder="$t('configureServer.port')" type="number" v-model="v2ray.port"
-              expanded />
-          </b-field>
-          <b-field label="ID" label-position="on-border">
-            <b-input ref="v2ray_id" required placeholder="UserID" v-model="v2ray.id" expanded />
-          </b-field>
-          <b-field v-if="v2ray.protocol === 'vmess'" label="AlterID" label-position="on-border">
-            <b-input ref="v2ray_aid" placeholder="AlterID" type="number" min="0" max="65535" v-model="v2ray.aid"
-              expanded />
-          </b-field>
-          <b-field v-if="v2ray.protocol === 'vmess'" label="Security" label-position="on-border">
-            <b-select v-model="v2ray.scy" expanded required>
-              <option value="auto">Auto</option>
-              <option value="aes-256-gcm">aes-256-gcm</option>
-              <option value="aes-128-gcm">aes-128-gcm</option>
-              <option value="chacha20-poly1305">chacha20-poly1305</option>
-              <option value="xchacha20-poly1305">xchacha20-poly1305</option>
-              <option value="none">none</option>
-              <option value="zero">zero</option>
-            </b-select>
-          </b-field>
-          <b-field v-show="v2ray.type !== 'dtls'" label="TLS" label-position="on-border">
-            <b-select v-model="v2ray.tls" expanded @input="handleNetworkChange">
-              <option value="none">{{ $t("setting.options.off") }}</option>
-              <option value="tls">tls</option>
-              <option v-if="variant() === 'xray'" value="reality"> reality </option>
-              <option v-if="variant() === 'xray'" value="xtls">xtls</option>
-            </b-select>
-          </b-field>
-          <b-field v-if="v2ray.tls !== 'none'" label="SNI" label-position="on-border">
-            <b-input ref="v2ray_sni" v-model="v2ray.sni" placeholder="SNI" expanded />
-          </b-field>
-          <b-field v-show="v2ray.tls === 'tls' || v2ray.tls === 'reality'" label="uTLS fingerprint"
-            label-position="on-border">
-            <b-select ref="v2ray_fp" v-model="v2ray.fp" expanded>
-              <option value="">empty</option>
-              <option value="chrome">chrome</option>
-              <option value="firefox">firefox</option>
-              <option value="safari">safari</option>
-              <option value="ios">ios</option>
-              <option value="android">android</option>
-              <option value="edge">edge</option>
-              <option value="360">360</option>
-              <option value="qq">qq</option>
-              <option value="random">random</option>
-              <option value="randomized">randomized</option>
-            </b-select>
-          </b-field>
-          <b-field v-if="v2ray.protocol === 'vless' && v2ray.tls !== 'none'" label="Encryption" label-position="on-border">
-            <b-input ref="v2ray_encryption" v-model="v2ray.scy" placeholder="none" expanded />
-          </b-field>
-          <b-field v-if="v2ray.protocol === 'vless' && v2ray.tls !== 'none'" label="Flow" label-position="on-border">
-            <b-input ref="v2ray_flow" v-model="v2ray.flow" placeholder="Flow" expanded />
-          </b-field>
-          <b-field v-show="v2ray.tls === 'reality'" label="pbk" label-position="on-border">
-            <b-input v-model="v2ray.pbk" placeholder="pbk" expanded />
-          </b-field>
-          <b-field v-show="v2ray.tls === 'reality'" label="sid" label-position="on-border">
-            <b-input v-model="v2ray.sid" placeholder="sid" expanded />
-          </b-field>
-          <b-field v-show="v2ray.tls === 'reality'" label="spx" label-position="on-border">
-            <b-input v-model="v2ray.spx" placeholder="spx" expanded />
-          </b-field>
-          <b-field v-show="v2ray.tls !== 'none'" label="Alpn" label-position="on-border">
-            <b-input v-model="v2ray.alpn" placeholder="h3,h2,http/1.1" expanded />
-          </b-field>
-          <b-field label-position="on-border">
-            <template slot="label"> AllowInsecure </template>
-            <b-tooltip v-show="v2ray.protocol === 'vless'" type="is-dark"
-              :label="$t('server.messages.notRecommend', { name: 'VLESS' })" multilined position="is-right">
-              <b-icon size="is-small" icon=" iconfont icon-help-circle-outline"
-                style="position: relative; top: 2px; right: 3px; font-weight: normal" />
-            </b-tooltip>
-            <b-select v-model="v2ray.allowInsecure" expanded required>
-              <option :value="false">{{ $t("operations.no") }}</option>
-              <option :value="true">{{ $t("operations.yes") }}</option>
-            </b-select>
-          </b-field>
-          <b-field label="Network" label-position="on-border">
-            <b-select v-model="v2ray.net" expanded @input="handleNetworkChange">
-              <option value="tcp">TCP</option>
-              <option value="kcp">mKCP</option>
-              <option value="ws">WebSocket</option>
-              <option value="h2">HTTP/2</option>
-              <option value="quic">QUIC</option>
-              <option value="grpc">gRPC</option>
-              <option v-if="variant() === 'xray'" value="xhttp">xhttp</option>
-            </b-select>
-          </b-field>
-          <b-field v-show="v2ray.net === 'tcp'" label="Header Type" label-position="on-border">
-            <b-select v-model="v2ray.type" expanded>
-              <option value="none">None</option>
-              <option value="http">HTTP</option>
-            </b-select>
-          </b-field>
-          <b-field v-show="v2ray.net === 'kcp' || v2ray.net === 'quic'" label="Header Type" label-position="on-border">
-            <b-select v-model="v2ray.type" expanded>
-              <option value="none">None</option>
-              <option value="srtp">SRTP</option>
-              <option value="utp">UTP</option>
-              <option value="wechat-video">Wechat-Video</option>
-              <option value="dtls">DTLS</option>
-              <option value="wireguard">Wireguard</option>
-            </b-select>
-          </b-field>
-          <b-field
-            v-show="v2ray.net === 'ws' || v2ray.net === 'h2' || (v2ray.net === 'tcp' && v2ray.type === 'http') || v2ray.net === 'xhttp'"
-            label="Path" label-position="on-border">
-            <b-input v-model="v2ray.path" placeholder="/" expanded />
-          </b-field>
-          <b-field
-            v-show="v2ray.net === 'ws' || v2ray.net === 'h2' || (v2ray.net === 'tcp' && v2ray.type === 'http') || v2ray.net === 'xhttp'"
-            label="Host" label-position="on-border">
-            <b-input v-model="v2ray.host" placeholder="Host" expanded />
-          </b-field>
-          <b-field
-            v-show="v2ray.net === 'ws'"
-            label="Max Early Data"
-            label-position="on-border"
-          >
-            <b-input
-              v-model="v2ray.maxEarlyData"
-              type="number"
-              placeholder="Max Early Data"
-              expanded
-            />
-          </b-field>
-          <b-field
-            v-show="v2ray.net === 'ws'"
-            label="Early Data Header Name"
-            label-position="on-border"
-          >
-            <b-input
-              v-model="v2ray.earlyDataHeaderName"
-              placeholder="Early Data Header Name"
-              expanded
-            />
-          </b-field>
-          <b-field v-show="v2ray.net === 'grpc'" label="Service Name" label-position="on-border">
-            <b-input ref="v2ray_service_name" v-model="v2ray.path" type="text" expanded />
-          </b-field>
-          <b-field
-            v-show="v2ray.net === 'grpc'"
-            label="MultiMode"
-            label-position="on-border"
-          >
-            <b-switch v-model="v2ray.multiMode">
-              {{ v2ray.multiMode ? $t('operations.yes') : $t('operations.no') }}
-            </b-switch>
-          </b-field>
-          <b-field
-            v-show="v2ray.net === 'grpc'"
-            label="Idle Timeout"
-            label-position="on-border"
-          >
-            <b-input
-              v-model="v2ray.idleTimeout"
-              type="number"
-              placeholder="Idle Timeout (s)"
-              expanded
-            />
-          </b-field>
-          <b-field
-            v-show="v2ray.net === 'grpc'"
-            label="Health Check Timeout"
-            label-position="on-border"
-          >
-            <b-input
-              v-model="v2ray.healthCheckTimeout"
-              type="number"
-              placeholder="Health Check Timeout (s)"
-              expanded
-            />
-          </b-field>
-          <b-field
-            v-show="v2ray.net === 'grpc'"
-            label="Permit Without Stream"
-            label-position="on-border"
-          >
-            <b-switch v-model="v2ray.permitWithoutStream">
-              {{ v2ray.permitWithoutStream ? $t('operations.yes') : $t('operations.no') }}
-            </b-switch>
-          </b-field>
-          <b-field
-            v-show="v2ray.net === 'grpc'"
-            label="Initial Windows Size"
-            label-position="on-border"
-          >
-            <b-input
-              v-model="v2ray.initialWindowsSize"
-              type="number"
-              placeholder="Initial Windows Size"
-              expanded
-            />
-          </b-field>
-          <b-field v-show="v2ray.net === 'quic'" label="Key" label-position="on-border">
-            <b-input v-model="v2ray.key" placeholder="key" expanded />
-          </b-field>
-          <b-field v-show="v2ray.net === 'quic'" label="Security" label-position="on-border">
-            <b-select v-model="v2ray.quicSecurity" expanded>
-              <option value="none">none</option>
-              <option value="aes-128-gcm">aes-128-gcm</option>
-              <option value="chacha20-poly1305">chacha20-poly1305</option>
-            </b-select>
-          </b-field>
-          <b-field v-show="v2ray.net === 'xhttp'" label="xhttp Mode" label-position="on-border">
-            <b-select v-model="v2ray.xhttpMode" expanded>
-              <option value="auto">auto</option>
-              <option value="download">download</option>
-              <option value="streaming">streaming</option>
-              <option value="packet">packet</option>
-              <option value="packet-up">packet-up</option>
-              <option value="stream-up">stream-up</option>
-              <option value="stream-one">stream-one</option>
-            </b-select>
-          </b-field>
-          <b-field v-show="v2ray.net === 'xhttp' && v2ray.xhttpMode === 'packet'" label="xhttp RawJson"
-            label-position="on-border">
-            <b-input v-model="v2ray.xhttpRawJson" type="textarea" placeholder='{"scy": "chacha20-poly1305"}' expanded />
-          </b-field>
+          <div v-if="tabChoice === 0">
+            <b-field label="Protocol" label-position="on-border">
+              <b-select v-model="v2ray.protocol" expanded @input="handleV2rayProtocolSwitch">
+                <option value="vmess">VMESS</option>
+                <option value="vless">VLESS</option>
+              </b-select>
+            </b-field>
+            <b-field label="Name" label-position="on-border">
+              <b-input ref="v2ray_name" v-model="v2ray.ps" :placeholder="$t('configureServer.servername')" expanded />
+            </b-field>
+            <b-field label="Host" label-position="on-border">
+              <b-input ref="v2ray_add" required placeholder="IP / HOST" v-model="v2ray.add" expanded />
+            </b-field>
+            <b-field label="Port" label-position="on-border">
+              <b-input ref="v2ray_port" required :placeholder="$t('configureServer.port')" type="number" v-model="v2ray.port"
+                expanded />
+            </b-field>
+            <b-field label="ID" label-position="on-border">
+              <b-input ref="v2ray_id" required placeholder="UserID" v-model="v2ray.id" expanded />
+            </b-field>
+            <b-field v-if="v2ray.protocol === 'vmess'" label="AlterID" label-position="on-border">
+              <b-input ref="v2ray_aid" placeholder="AlterID" type="number" min="0" max="65535" v-model="v2ray.aid"
+                expanded />
+            </b-field>
+            <b-field v-if="v2ray.protocol === 'vmess'" label="Security" label-position="on-border">
+              <b-select v-model="v2ray.scy" expanded required>
+                <option value="auto">Auto</option>
+                <option value="aes-256-gcm">aes-256-gcm</option>
+                <option value="aes-128-gcm">aes-128-gcm</option>
+                <option value="chacha20-poly1305">chacha20-poly1305</option>
+                <option value="xchacha20-poly1305">xchacha20-poly1305</option>
+                <option value="none">none</option>
+                <option value="zero">zero</option>
+              </b-select>
+            </b-field>
+            <b-field v-show="v2ray.type !== 'dtls'" label="TLS" label-position="on-border">
+              <b-select v-model="v2ray.tls" expanded @input="handleNetworkChange">
+                <option value="none">{{ $t("setting.options.off") }}</option>
+                <option value="tls">tls</option>
+                <option v-if="variant() === 'xray'" value="reality"> reality </option>
+                <option v-if="variant() === 'xray'" value="xtls">xtls</option>
+              </b-select>
+            </b-field>
+            <b-field v-if="v2ray.tls !== 'none'" label="SNI" label-position="on-border">
+              <b-input ref="v2ray_sni" v-model="v2ray.sni" placeholder="SNI" expanded />
+            </b-field>
+            <b-field v-show="v2ray.tls === 'tls' || v2ray.tls === 'reality'" label="uTLS fingerprint"
+              label-position="on-border">
+              <b-select ref="v2ray_fp" v-model="v2ray.fp" expanded>
+                <option value="">empty</option>
+                <option value="chrome">chrome</option>
+                <option value="firefox">firefox</option>
+                <option value="safari">safari</option>
+                <option value="ios">ios</option>
+                <option value="android">android</option>
+                <option value="edge">edge</option>
+                <option value="360">360</option>
+                <option value="qq">qq</option>
+                <option value="random">random</option>
+                <option value="randomized">randomized</option>
+              </b-select>
+            </b-field>
+            <b-field v-if="v2ray.protocol === 'vless' && v2ray.tls !== 'none'" label="Encryption" label-position="on-border">
+              <b-input ref="v2ray_encryption" v-model="v2ray.scy" placeholder="none" expanded />
+            </b-field>
+            <b-field v-if="v2ray.protocol === 'vless' && v2ray.tls !== 'none'" label="Flow" label-position="on-border">
+              <b-input ref="v2ray_flow" v-model="v2ray.flow" placeholder="Flow" expanded />
+            </b-field>
+            <b-field v-show="v2ray.tls === 'reality'" label="pbk" label-position="on-border">
+              <b-input v-model="v2ray.pbk" placeholder="pbk" expanded />
+            </b-field>
+            <b-field v-show="v2ray.tls === 'reality'" label="sid" label-position="on-border">
+              <b-input v-model="v2ray.sid" placeholder="sid" expanded />
+            </b-field>
+            <b-field v-show="v2ray.tls === 'reality'" label="spx" label-position="on-border">
+              <b-input v-model="v2ray.spx" placeholder="spx" expanded />
+            </b-field>
+            <b-field v-show="v2ray.tls !== 'none'" label="Alpn" label-position="on-border">
+              <b-input v-model="v2ray.alpn" placeholder="h3,h2,http/1.1" expanded />
+            </b-field>
+            <b-field label-position="on-border">
+              <template slot="label"> AllowInsecure </template>
+              <b-tooltip v-show="v2ray.protocol === 'vless'" type="is-dark"
+                :label="$t('server.messages.notRecommend', { name: 'VLESS' })" multilined position="is-right">
+                <b-icon size="is-small" icon=" iconfont icon-help-circle-outline"
+                  style="position: relative; top: 2px; right: 3px; font-weight: normal" />
+              </b-tooltip>
+              <b-select v-model="v2ray.allowInsecure" expanded required>
+                <option :value="false">{{ $t("operations.no") }}</option>
+                <option :value="true">{{ $t("operations.yes") }}</option>
+              </b-select>
+            </b-field>
+            <b-field label="Network" label-position="on-border">
+              <b-select v-model="v2ray.net" expanded @input="handleNetworkChange">
+                <option value="tcp">TCP</option>
+                <option value="kcp">mKCP</option>
+                <option value="ws">WebSocket</option>
+                <option value="h2">HTTP/2</option>
+                <option value="quic">QUIC</option>
+                <option value="grpc">gRPC</option>
+                <option v-if="variant() === 'xray'" value="xhttp">xhttp</option>
+              </b-select>
+            </b-field>
+            <b-field v-show="v2ray.net === 'tcp'" label="Header Type" label-position="on-border">
+              <b-select v-model="v2ray.type" expanded>
+                <option value="none">None</option>
+                <option value="http">HTTP</option>
+              </b-select>
+            </b-field>
+            <b-field v-show="v2ray.net === 'kcp' || v2ray.net === 'quic'" label="Header Type" label-position="on-border">
+              <b-select v-model="v2ray.type" expanded>
+                <option value="none">None</option>
+                <option value="srtp">SRTP</option>
+                <option value="utp">UTP</option>
+                <option value="wechat-video">Wechat-Video</option>
+                <option value="dtls">DTLS</option>
+                <option value="wireguard">Wireguard</option>
+              </b-select>
+            </b-field>
+            <b-field
+              v-show="v2ray.net === 'ws' || v2ray.net === 'h2' || (v2ray.net === 'tcp' && v2ray.type === 'http') || v2ray.net === 'xhttp'"
+              label="Path" label-position="on-border">
+              <b-input v-model="v2ray.path" placeholder="/" expanded />
+            </b-field>
+            <b-field
+              v-show="v2ray.net === 'ws' || v2ray.net === 'h2' || (v2ray.net === 'tcp' && v2ray.type === 'http') || v2ray.net === 'xhttp'"
+              label="Host" label-position="on-border">
+              <b-input v-model="v2ray.host" placeholder="Host" expanded />
+            </b-field>
+            <b-field
+              v-show="v2ray.net === 'ws'"
+              label="Max Early Data"
+              label-position="on-border"
+            >
+              <b-input
+                v-model="v2ray.maxEarlyData"
+                type="number"
+                placeholder="Max Early Data"
+                expanded
+              />
+            </b-field>
+            <b-field
+              v-show="v2ray.net === 'ws'"
+              label="Early Data Header Name"
+              label-position="on-border"
+            >
+              <b-input
+                v-model="v2ray.earlyDataHeaderName"
+                placeholder="Early Data Header Name"
+                expanded
+              />
+            </b-field>
+            <b-field v-show="v2ray.net === 'grpc'" label="Service Name" label-position="on-border">
+              <b-input ref="v2ray_service_name" v-model="v2ray.path" type="text" expanded />
+            </b-field>
+            <b-field
+              v-show="v2ray.net === 'grpc'"
+              label="MultiMode"
+              label-position="on-border"
+            >
+              <b-switch v-model="v2ray.multiMode">
+                {{ v2ray.multiMode ? $t('operations.yes') : $t('operations.no') }}
+              </b-switch>
+            </b-field>
+            <b-field
+              v-show="v2ray.net === 'grpc'"
+              label="Idle Timeout"
+              label-position="on-border"
+            >
+              <b-input
+                v-model="v2ray.idleTimeout"
+                type="number"
+                placeholder="Idle Timeout (s)"
+                expanded
+              />
+            </b-field>
+            <b-field
+              v-show="v2ray.net === 'grpc'"
+              label="Health Check Timeout"
+              label-position="on-border"
+            >
+              <b-input
+                v-model="v2ray.healthCheckTimeout"
+                type="number"
+                placeholder="Health Check Timeout (s)"
+                expanded
+              />
+            </b-field>
+            <b-field
+              v-show="v2ray.net === 'grpc'"
+              label="Permit Without Stream"
+              label-position="on-border"
+            >
+              <b-switch v-model="v2ray.permitWithoutStream">
+                {{ v2ray.permitWithoutStream ? $t('operations.yes') : $t('operations.no') }}
+              </b-switch>
+            </b-field>
+            <b-field
+              v-show="v2ray.net === 'grpc'"
+              label="Initial Windows Size"
+              label-position="on-border"
+            >
+              <b-input
+                v-model="v2ray.initialWindowsSize"
+                type="number"
+                placeholder="Initial Windows Size"
+                expanded
+              />
+            </b-field>
+            <b-field v-show="v2ray.net === 'quic'" label="Key" label-position="on-border">
+              <b-input v-model="v2ray.key" placeholder="key" expanded />
+            </b-field>
+            <b-field v-show="v2ray.net === 'quic'" label="Security" label-position="on-border">
+              <b-select v-model="v2ray.quicSecurity" expanded>
+                <option value="none">none</option>
+                <option value="aes-128-gcm">aes-128-gcm</option>
+                <option value="chacha20-poly1305">chacha20-poly1305</option>
+              </b-select>
+            </b-field>
+            <b-field v-show="v2ray.net === 'xhttp'" label="xhttp Mode" label-position="on-border">
+              <b-select v-model="v2ray.xhttpMode" expanded>
+                <option value="auto">auto</option>
+                <option value="download">download</option>
+                <option value="streaming">streaming</option>
+                <option value="packet">packet</option>
+                <option value="packet-up">packet-up</option>
+                <option value="stream-up">stream-up</option>
+                <option value="stream-one">stream-one</option>
+              </b-select>
+            </b-field>
+            <b-field v-show="v2ray.net === 'xhttp' && v2ray.xhttpMode === 'packet'" label="xhttp RawJson"
+              label-position="on-border">
+              <b-input v-model="v2ray.xhttpRawJson" type="textarea" placeholder='{"scy": "chacha20-poly1305"}' expanded />
+            </b-field>
+          </div>
         </b-tab-item>
 
         <b-tab-item label="WireGuard">
+          <div v-if="tabChoice === 1">
           <b-field label="Name" label-position="on-border">
             <b-input ref="wireguard_name" v-model="wireguard.name" :placeholder="$t('configureServer.servername')" expanded />
           </b-field>
@@ -280,9 +283,11 @@
           <b-field label="Endpoint" label-position="on-border">
             <b-input ref="wireguard_endpoint" v-model="wireguard.endpoint" placeholder="Endpoint (optional, default same as Address:Port)" expanded />
           </b-field>
+          </div>
         </b-tab-item>
 
         <b-tab-item label="SS">
+          <div v-if="tabChoice === 2">
           <b-field label="Name" label-position="on-border">
             <b-input ref="ss_name" v-model="ss.name" :placeholder="$t('configureServer.servername')" expanded />
           </b-field>
@@ -337,6 +342,7 @@
         </b-tab-item>
 
         <b-tab-item label="SSR">
+          <div v-if="tabChoice === 3">
           <b-field label="Name" label-position="on-border">
             <b-input ref="ssr_name" v-model="ssr.name" :placeholder="$t('configureServer.servername')" expanded />
           </b-field>
@@ -393,6 +399,7 @@
         </b-tab-item>
 
         <b-tab-item label="Trojan">
+          <div v-if="tabChoice === 4">
           <b-field label="Name" label-position="on-border">
             <b-input ref="trojan_name" v-model="trojan.name" :placeholder="$t('configureServer.servername')" expanded />
           </b-field>
@@ -431,6 +438,7 @@
         </b-tab-item>
 
         <b-tab-item label="Juicity">
+          <div v-if="tabChoice === 5">
           <b-field label="Name" label-position="on-border">
             <b-input ref="juicity_name" v-model="juicity.name" :placeholder="$t('configureServer.servername')"
               expanded />
@@ -471,6 +479,7 @@
         </b-tab-item>
 
         <b-tab-item label="Tuic">
+          <div v-if="tabChoice === 6">
           <b-field label="Name" label-position="on-border">
             <b-input ref="tuic_name" v-model="tuic.name" :placeholder="$t('configureServer.servername')" expanded />
           </b-field>
@@ -518,12 +527,14 @@
             <template slot="label"> UDP relay mode </template>
             <b-select ref="tuic_udp_relay_mode" v-model="tuic.udpRelayMode" expanded required>
               <option value="native">native</option>
+          </div>
               <option value="quic">quic</option>
             </b-select>
           </b-field>
         </b-tab-item>
 
         <b-tab-item label="Hysteria2">
+          <div v-if="tabChoice === 7">
           <b-field label="Name" label-position="on-border">
             <b-input ref="hysteria2_name" v-model="hysteria2.name" :placeholder="$t('configureServer.servername')"
               expanded />
@@ -581,11 +592,13 @@
             </template>
             <b-checkbox v-model="hysteria2.finalMask">
               Use native Xray implementation (requires Xray-core v26.1.23+)
+          </div>
             </b-checkbox>
           </b-field>
         </b-tab-item>
 
         <b-tab-item label="HTTP">
+          <div v-if="tabChoice === 8">
           <b-field label="Protocol" label-position="on-border">
             <b-select v-model="http.protocol" expanded>
               <option value="http">HTTP</option>
@@ -609,9 +622,11 @@
           <b-field label="Password" label-position="on-border">
             <b-input ref="http_password" v-model="http.password" :placeholder="$t('configureServer.password')"
               expanded />
+          </div>
           </b-field>
         </b-tab-item>
         <b-tab-item label="SOCKS5">
+          <div v-if="tabChoice === 9">
           <b-field label="Name" label-position="on-border">
             <b-input ref="socks5_name" v-model="socks5.name" :placeholder="$t('configureServer.servername')" expanded />
           </b-field>
@@ -629,9 +644,11 @@
           <b-field label="Password" label-position="on-border">
             <b-input ref="socks5_password" v-model="socks5.password" :placeholder="$t('configureServer.password')"
               expanded />
+          </div>
           </b-field>
         </b-tab-item>
         <b-tab-item label="AnyTLS">
+          <div v-if="tabChoice === 10">
           <b-field label="Name" label-position="on-border">
             <b-input ref="anytls_name" v-model="anytls.name" :placeholder="$t('configureServer.servername')" expanded />
           </b-field>
@@ -652,6 +669,7 @@
             <template slot="label"> AllowInsecure </template>
             <b-select ref="anytls_allow_insecure" v-model="anytls.allowInsecure" expanded required>
               <option :value="false">{{ $t("operations.no") }}</option>
+          </div>
               <option :value="true">{{ $t("operations.yes") }}</option>
             </b-select>
           </b-field>
@@ -833,6 +851,7 @@ export default {
         persistentKeepalive: "",
         preSharedKey: "",
         endpoint: "",
+        protocol: "wireguard",
       },
     };
   },
@@ -1198,15 +1217,16 @@ export default {
           name: decodeURIComponent(u.hash),
           address: u.host,
           port: u.port,
-          publicKey: decodeURIComponent(u.username),
-          privateKey: u.params.privateKey || "",
-          localAddress: u.params.localAddress || "",
+          privateKey: decodeURIComponent(u.username),
+          publicKey: u.params.publicKey || "",
+          localAddress: u.params.address || u.params.localAddress || "",
           dns: u.params.dns || "",
           mtu: u.params.mtu || "",
           allowedIPs: u.params.allowedIPs || "",
           persistentKeepalive: u.params.persistentKeepalive || "",
           preSharedKey: u.params.preSharedKey || "",
           endpoint: u.params.endpoint || "",
+          protocol: "wireguard",
         };
       }
       return null;
@@ -1486,11 +1506,11 @@ export default {
           });
         case "wireguard":
           query = {};
-          if (srcObj.privateKey) {
-            query.privateKey = srcObj.privateKey;
+          if (srcObj.publicKey) {
+            query.publicKey = srcObj.publicKey;
           }
           if (srcObj.localAddress) {
-            query.localAddress = srcObj.localAddress;
+            query.address = srcObj.localAddress;
           }
           if (srcObj.dns) {
             query.dns = srcObj.dns;
@@ -1512,7 +1532,7 @@ export default {
           }
           return generateURL({
             protocol: "wireguard",
-            username: srcObj.publicKey,
+            username: srcObj.privateKey,
             host: srcObj.address,
             port: srcObj.port,
             hash: srcObj.name,
@@ -1567,28 +1587,34 @@ export default {
     },
     async handleClickSubmit() {
       let valid = true;
+      const prefixMap = {
+        0: "v2ray_",
+        1: "wireguard_",
+        2: "ss_",
+        3: "ssr_",
+        4: "trojan_",
+        5: "juicity_",
+        6: "tuic_",
+        7: "hysteria2_",
+        8: "http_",
+        9: "socks5_",
+        10: "anytls_",
+      };
+      const currentPrefix = prefixMap[this.tabChoice];
       for (let k in this.$refs) {
         if (!this.$refs.hasOwnProperty(k)) continue;
-        if (this.tabChoice === 0 && !k.startsWith("v2ray_")) continue;
-        if (this.tabChoice === 1 && !k.startsWith("wireguard_")) continue;
-        if (this.tabChoice === 2 && !k.startsWith("ss_")) continue;
-        if (this.tabChoice === 3 && !k.startsWith("ssr_")) continue;
-        if (this.tabChoice === 4 && !k.startsWith("trojan_")) continue;
-        if (this.tabChoice === 5 && !k.startsWith("juicity_")) continue;
-        if (this.tabChoice === 6 && !k.startsWith("tuic_")) continue;
-        if (this.tabChoice === 7 && !k.startsWith("hysteria2_")) continue;
-        if (this.tabChoice === 8 && !k.startsWith("http_")) continue;
-        if (this.tabChoice === 9 && !k.startsWith("socks5_")) continue;
-        if (this.tabChoice === 10 && !k.startsWith("anytls_")) continue;
+        if (!k.startsWith(currentPrefix)) continue;
+
         let x = this.$refs[k];
+        if (!x) continue;
+        let el = x.$el || x;
         if (
-          x &&
-          x.$el.offsetParent &&
+          el.offsetParent &&
           x.hasOwnProperty("checkHtml5Validity") &&
           typeof x.checkHtml5Validity === "function" &&
           !x.checkHtml5Validity()
         ) {
-          console.error("validate failed", x);
+          console.error("validate failed", k, x);
           valid = false;
         }
       }

--- a/gui/src/components/modalServer.vue
+++ b/gui/src/components/modalServer.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="modal-card" style="max-width: 520px; margin: auto">
+  <div class="modal-card">
     <header class="modal-card-head">
       <p class="modal-card-title">
         {{ $tc("configureServer.title", readonly ? 2 : 1) }}
       </p>
     </header>
     <section ref="section" :class="{ 'modal-card-body': true }">
-      <b-tabs v-model="tabChoice" position="is-centered" class="block" type="is-boxed is-twitter same-width-5">
+      <b-tabs v-model="tabChoice" class="block" type="is-boxed is-twitter" vertical>
         <b-tab-item label="V2RAY">
           <b-field label="Protocol" label-position="on-border">
             <b-select v-model="v2ray.protocol" expanded @input="handleV2rayProtocolSwitch">
@@ -18,17 +18,17 @@
             <b-input ref="v2ray_name" v-model="v2ray.ps" :placeholder="$t('configureServer.servername')" expanded />
           </b-field>
           <b-field label="Host" label-position="on-border">
-            <b-input ref="v2ray_add" v-model="v2ray.add" required placeholder="IP / HOST" expanded />
+            <b-input ref="v2ray_add" required placeholder="IP / HOST" v-model="v2ray.add" expanded />
           </b-field>
           <b-field label="Port" label-position="on-border">
-            <b-input ref="v2ray_port" v-model="v2ray.port" required :placeholder="$t('configureServer.port')"
-              type="number" expanded />
+            <b-input ref="v2ray_port" required :placeholder="$t('configureServer.port')" type="number" v-model="v2ray.port"
+              expanded />
           </b-field>
           <b-field label="ID" label-position="on-border">
-            <b-input ref="v2ray_id" v-model="v2ray.id" required placeholder="UserID" expanded />
+            <b-input ref="v2ray_id" required placeholder="UserID" v-model="v2ray.id" expanded />
           </b-field>
           <b-field v-if="v2ray.protocol === 'vmess'" label="AlterID" label-position="on-border">
-            <b-input ref="v2ray_aid" v-model="v2ray.aid" placeholder="AlterID" type="number" min="0" max="65535"
+            <b-input ref="v2ray_aid" placeholder="AlterID" type="number" min="0" max="65535" v-model="v2ray.aid"
               expanded />
           </b-field>
           <b-field v-if="v2ray.protocol === 'vmess'" label="Security" label-position="on-border">
@@ -46,33 +46,16 @@
             <b-select v-model="v2ray.tls" expanded @input="handleNetworkChange">
               <option value="none">{{ $t("setting.options.off") }}</option>
               <option value="tls">tls</option>
-              <option v-if="variant() === 'xray'" value="reality">
-                reality
-              </option>
+              <option v-if="variant() === 'xray'" value="reality"> reality </option>
               <option v-if="variant() === 'xray'" value="xtls">xtls</option>
             </b-select>
           </b-field>
-          <b-field
-            v-if="v2ray.tls !== 'none'"
-            label="SNI"
-            label-position="on-border"
-          >
-            <b-input
-              ref="v2ray_sni"
-              v-model="v2ray.sni"
-              placeholder="SNI"
-              expanded
-            />
+          <b-field v-if="v2ray.tls !== 'none'" label="SNI" label-position="on-border">
+            <b-input ref="v2ray_sni" v-model="v2ray.sni" placeholder="SNI" expanded />
           </b-field>
-          <b-field
-v-show="v2ray.tls === 'tls' || v2ray.tls === 'reality'" label="uTLS fingerprint"
-            label-position="on-border"
-          >
-            <b-select
-              ref="v2ray_fp"
-              v-model="v2ray.fp"
-              expanded
-            >
+          <b-field v-show="v2ray.tls === 'tls' || v2ray.tls === 'reality'" label="uTLS fingerprint"
+            label-position="on-border">
+            <b-select ref="v2ray_fp" v-model="v2ray.fp" expanded>
               <option value="">empty</option>
               <option value="chrome">chrome</option>
               <option value="firefox">firefox</option>
@@ -80,44 +63,19 @@ v-show="v2ray.tls === 'tls' || v2ray.tls === 'reality'" label="uTLS fingerprint"
               <option value="ios">ios</option>
               <option value="android">android</option>
               <option value="edge">edge</option>
+              <option value="360">360</option>
+              <option value="qq">qq</option>
               <option value="random">random</option>
               <option value="randomized">randomized</option>
             </b-select>
           </b-field>
-          <b-field
-            v-show="v2ray.tls === 'tls'"
-            label="Alpn"
-            label-position="on-border"
-          >
-            <b-input v-model="v2ray.alpn" placeholder="h3,h2,http/1.1" expanded />
+          <b-field v-if="v2ray.protocol === 'vless' && v2ray.tls !== 'none'" label="Encryption" label-position="on-border">
+            <b-input ref="v2ray_encryption" v-model="v2ray.scy" placeholder="none" expanded />
           </b-field>
-          <b-field
-            v-if="v2ray.protocol === 'vless' && v2ray.tls !== 'none'"
-            label="Encryption"
-            label-position="on-border"
-          >
-            <b-input v-model="v2ray.scy" placeholder="none" expanded />
+          <b-field v-if="v2ray.protocol === 'vless' && v2ray.tls !== 'none'" label="Flow" label-position="on-border">
+            <b-input ref="v2ray_flow" v-model="v2ray.flow" placeholder="Flow" expanded />
           </b-field>
-          <b-field
-v-if="v2ray.protocol === 'vless' && v2ray.tls !== 'none'" ref="v2ray_flow" label="Flow"
-            label-position="on-border"
-          >
-            <b-select
-              ref="v2ray_flow"
-              v-model="v2ray.flow"
-              placeholder="Flow"
-              expanded
-            >
-              <option value="none">{{ $t("setting.options.off") }}</option>
-              <option value="xtls-rprx-vision">xtls-rprx-vision</option>
-              <option value="xtls-rprx-vision-udp443">xtls-rprx-vision-udp443</option>
-            </b-select>
-          </b-field>
-          <b-field
-            v-show="v2ray.tls === 'reality'"
-            label="pbk"
-            label-position="on-border"
-          >
+          <b-field v-show="v2ray.tls === 'reality'" label="pbk" label-position="on-border">
             <b-input v-model="v2ray.pbk" placeholder="pbk" expanded />
           </b-field>
           <b-field v-show="v2ray.tls === 'reality'" label="sid" label-position="on-border">
@@ -126,108 +84,57 @@ v-if="v2ray.protocol === 'vless' && v2ray.tls !== 'none'" ref="v2ray_flow" label
           <b-field v-show="v2ray.tls === 'reality'" label="spx" label-position="on-border">
             <b-input v-model="v2ray.spx" placeholder="spx" expanded />
           </b-field>
-          <b-field v-show="v2ray.tls !== 'none'" label-position="on-border">
-            <template slot="label">
-              AllowInsecure
-              <b-tooltip v-show="v2ray.protocol === 'vless'" type="is-dark"
-                :label="$t('server.messages.notRecommend', { name: 'VLESS' })" multilined position="is-right">
-                <b-icon size="is-small" icon=" iconfont icon-help-circle-outline" style="
-                    position: relative;
-                    top: 2px;
-                    right: 3px;
-                    font-weight: normal;
-                  " />
-              </b-tooltip>
-            </template>
-            <b-select ref="v2ray_allow_insecure" v-model="v2ray.allowInsecure" expanded required>
+          <b-field v-show="v2ray.tls !== 'none'" label="Alpn" label-position="on-border">
+            <b-input v-model="v2ray.alpn" placeholder="h3,h2,http/1.1" expanded />
+          </b-field>
+          <b-field label-position="on-border">
+            <template slot="label"> AllowInsecure </template>
+            <b-tooltip v-show="v2ray.protocol === 'vless'" type="is-dark"
+              :label="$t('server.messages.notRecommend', { name: 'VLESS' })" multilined position="is-right">
+              <b-icon size="is-small" icon=" iconfont icon-help-circle-outline"
+                style="position: relative; top: 2px; right: 3px; font-weight: normal" />
+            </b-tooltip>
+            <b-select v-model="v2ray.allowInsecure" expanded required>
               <option :value="false">{{ $t("operations.no") }}</option>
               <option :value="true">{{ $t("operations.yes") }}</option>
             </b-select>
           </b-field>
           <b-field label="Network" label-position="on-border">
-            <b-select ref="v2ray_net" v-model="v2ray.net" expanded required @input="handleNetworkChange">
+            <b-select v-model="v2ray.net" expanded @input="handleNetworkChange">
               <option value="tcp">TCP</option>
               <option value="kcp">mKCP</option>
               <option value="ws">WebSocket</option>
               <option value="h2">HTTP/2</option>
-              <option value="grpc">gRPC</option>
               <option value="quic">QUIC</option>
-              <option value="xhttp">XHTTP</option>
+              <option value="grpc">gRPC</option>
+              <option v-if="variant() === 'xray'" value="xhttp">xhttp</option>
             </b-select>
           </b-field>
-          <b-field v-show="v2ray.net === 'tcp'" label="Type" label-position="on-border">
+          <b-field v-show="v2ray.net === 'tcp'" label="Header Type" label-position="on-border">
             <b-select v-model="v2ray.type" expanded>
-              <option value="none">
-                {{ $t("configureServer.noObfuscation") }}
-              </option>
-              <option value="http">
-                {{ $t("configureServer.httpObfuscation") }}
-              </option>
+              <option value="none">None</option>
+              <option value="http">HTTP</option>
             </b-select>
           </b-field>
-          <b-field v-show="v2ray.protocol === 'vless' && v2ray.net == 'quic'" label="QUIC Security"
-            label-position="on-border">
-            <b-select v-model="v2ray.quicSecurity" expanded>
-              <option value="none">none</option>
-              <option value="aes-128-gcm">aes-128-gcm</option>
-              <option value="chacha20-poly1305">chacha20-poly1305</option>
-            </b-select>
-          </b-field>
-          <b-field v-show="v2ray.net === 'kcp' || v2ray.net === 'quic'" label="Type" label-position="on-border">
+          <b-field v-show="v2ray.net === 'kcp' || v2ray.net === 'quic'" label="Header Type" label-position="on-border">
             <b-select v-model="v2ray.type" expanded>
-              <option value="none">
-                {{ $t("configureServer.noObfuscation") }}
-              </option>
-              <option value="srtp">
-                {{ $t("configureServer.srtpObfuscation") }}
-              </option>
-              <option value="utp">
-                {{ $t("configureServer.utpObfuscation") }}
-              </option>
-              <option value="wechat-video">
-                {{ $t("configureServer.wechatVideoObfuscation") }}
-              </option>
-              <option value="dtls">
-                {{
-                  `${$t("configureServer.dtlsObfuscation")}(${$t(
-                    "configureServer.forceTLS"
-                  )})`
-                }}
-              </option>
-              <option value="wireguard">
-                {{ $t("configureServer.wireguardObfuscation") }}
-              </option>
+              <option value="none">None</option>
+              <option value="srtp">SRTP</option>
+              <option value="utp">UTP</option>
+              <option value="wechat-video">Wechat-Video</option>
+              <option value="dtls">DTLS</option>
+              <option value="wireguard">Wireguard</option>
             </b-select>
           </b-field>
           <b-field
-v-show="v2ray.net === 'ws' ||
-              v2ray.net === 'h2' ||
-              v2ray.net === 'xhttp' ||
-              v2ray.tls === 'tls' ||
-              (v2ray.net === 'tcp' && v2ray.type === 'http')
-            "
-            label="Host"
-            label-position="on-border"
-          >
-            <b-input
-              v-model="v2ray.host"
-              :placeholder="$t('configureServer.hostObfuscation')"
-              expanded
-            />
+            v-show="v2ray.net === 'ws' || v2ray.net === 'h2' || (v2ray.net === 'tcp' && v2ray.type === 'http') || v2ray.net === 'xhttp'"
+            label="Path" label-position="on-border">
+            <b-input v-model="v2ray.path" placeholder="/" expanded />
           </b-field>
           <b-field
-v-show="v2ray.net === 'ws' ||
-              v2ray.net === 'h2' ||
-              (v2ray.net === 'tcp' && v2ray.type === 'http')
-            "
-            label="Path"
-            label-position="on-border"
-          >
-            <b-input
-              v-model="v2ray.path"
-              :placeholder="$t('configureServer.pathObfuscation')"
-              expanded
-            />
+            v-show="v2ray.net === 'ws' || v2ray.net === 'h2' || (v2ray.net === 'tcp' && v2ray.type === 'http') || v2ray.net === 'xhttp'"
+            label="Host" label-position="on-border">
+            <b-input v-model="v2ray.host" placeholder="Host" expanded />
           </b-field>
           <b-field
             v-show="v2ray.net === 'ws'"
@@ -252,28 +159,8 @@ v-show="v2ray.net === 'ws' ||
               expanded
             />
           </b-field>
-          <b-field
-            v-show="v2ray.net === 'mkcp' || v2ray.net === 'kcp'"
-            label="Seed"
-            label-position="on-border"
-          >
-            <b-input
-              v-model="v2ray.path"
-              :placeholder="$t('configureServer.seedObfuscation')"
-              expanded
-            />
-          </b-field>
-          <b-field
-            v-show="v2ray.net === 'grpc'"
-            label="Service Name"
-            label-position="on-border"
-          >
-            <b-input
-              ref="v2ray_service_name"
-              v-model="v2ray.path"
-              type="text"
-              expanded
-            />
+          <b-field v-show="v2ray.net === 'grpc'" label="Service Name" label-position="on-border">
+            <b-input ref="v2ray_service_name" v-model="v2ray.path" type="text" expanded />
           </b-field>
           <b-field
             v-show="v2ray.net === 'grpc'"
@@ -329,51 +216,33 @@ v-show="v2ray.net === 'ws' ||
               expanded
             />
           </b-field>
-          <b-field
-            v-show="v2ray.net === 'xhttp'"
-            label="Path"
-            label-position="on-border"
-          >
-            <b-input
-              v-model="v2ray.path"
-              :placeholder="$t('configureServer.pathObfuscation')"
-              expanded
-            />
+          <b-field v-show="v2ray.net === 'quic'" label="Key" label-position="on-border">
+            <b-input v-model="v2ray.key" placeholder="key" expanded />
           </b-field>
-          <b-field
-            v-show="v2ray.net === 'xhttp'"
-            label="Mode"
-            label-position="on-border"
-          >
+          <b-field v-show="v2ray.net === 'quic'" label="Security" label-position="on-border">
+            <b-select v-model="v2ray.quicSecurity" expanded>
+              <option value="none">none</option>
+              <option value="aes-128-gcm">aes-128-gcm</option>
+              <option value="chacha20-poly1305">chacha20-poly1305</option>
+            </b-select>
+          </b-field>
+          <b-field v-show="v2ray.net === 'xhttp'" label="xhttp Mode" label-position="on-border">
             <b-select v-model="v2ray.xhttpMode" expanded>
               <option value="auto">auto</option>
+              <option value="download">download</option>
+              <option value="streaming">streaming</option>
+              <option value="packet">packet</option>
               <option value="packet-up">packet-up</option>
               <option value="stream-up">stream-up</option>
               <option value="stream-one">stream-one</option>
             </b-select>
           </b-field>
-          <b-field
-            v-show="v2ray.net === 'xhttp'"
-            label="Extra Raw JSON"
-            label-position="on-border"
-          >
-            <b-input
-              v-model="v2ray.xhttpRawJson"
-              placeholder="{XHTTPObject}"
-              expanded
-            />
-          </b-field>
-          <b-field
-            v-show="v2ray.net === 'quic'"
-            label="Key"
-            label-position="on-border"
-          >
-            <b-input
-ref="v2ray_key" v-model="v2ray.key" :placeholder="$t('configureServer.password')"
-              expanded
-            />
+          <b-field v-show="v2ray.net === 'xhttp' && v2ray.xhttpMode === 'packet'" label="xhttp RawJson"
+            label-position="on-border">
+            <b-input v-model="v2ray.xhttpRawJson" type="textarea" placeholder='{"scy": "chacha20-poly1305"}' expanded />
           </b-field>
         </b-tab-item>
+
         <b-tab-item label="WireGuard">
           <b-field label="Name" label-position="on-border">
             <b-input ref="wireguard_name" v-model="wireguard.name" :placeholder="$t('configureServer.servername')" expanded />
@@ -412,26 +281,33 @@ ref="v2ray_key" v-model="v2ray.key" :placeholder="$t('configureServer.password')
             <b-input ref="wireguard_endpoint" v-model="wireguard.endpoint" placeholder="Endpoint (optional, default same as Address:Port)" expanded />
           </b-field>
         </b-tab-item>
+
         <b-tab-item label="SS">
           <b-field label="Name" label-position="on-border">
             <b-input ref="ss_name" v-model="ss.name" :placeholder="$t('configureServer.servername')" expanded />
           </b-field>
           <b-field label="Host" label-position="on-border">
-            <b-input ref="ss_server" v-model="ss.server" required placeholder="IP / HOST" expanded />
+            <b-input ref="ss_server" required placeholder="IP / HOST" v-model="ss.server" expanded />
           </b-field>
           <b-field label="Port" label-position="on-border">
-            <b-input ref="ss_port" v-model="ss.port" required :placeholder="$t('configureServer.port')" type="number"
+            <b-input ref="ss_port" required :placeholder="$t('configureServer.port')" type="number" v-model="ss.port"
               expanded />
           </b-field>
           <b-field label="Password" label-position="on-border">
-            <b-input ref="ss_password" v-model="ss.password" required :placeholder="$t('configureServer.password')"
+            <b-input ref="ss_password" required :placeholder="$t('configureServer.password')" v-model="ss.password"
               expanded />
           </b-field>
           <b-field label="Method" label-position="on-border">
-            <b-select ref="ss_method" v-model="ss.method" expanded required>
-              <option value="2022-blake3-aes-128-gcm">2022-blake3-aes-128-gcm</option>
-              <option value="2022-blake3-aes-256-gcm">2022-blake3-aes-256-gcm</option>
-              <option value="2022-blake3-chacha20-poly1305">2022-blake3-chacha20-poly1305</option>
+            <b-select v-model="ss.method" expanded required>
+              <option value="2022-blake3-aes-128-gcm">
+                2022-blake3-aes-128-gcm
+              </option>
+              <option value="2022-blake3-aes-256-gcm">
+                2022-blake3-aes-256-gcm
+              </option>
+              <option value="2022-blake3-chacha20-poly1305">
+                2022-blake3-chacha20-poly1305
+              </option>
               <option value="aes-128-gcm">aes-128-gcm</option>
               <option value="aes-256-gcm">aes-256-gcm</option>
               <option value="chacha20-poly1305">chacha20-poly1305</option>
@@ -443,58 +319,14 @@ ref="v2ray_key" v-model="v2ray.key" :placeholder="$t('configureServer.password')
             </b-select>
           </b-field>
           <b-field label="Plugin" label-position="on-border">
-            <b-select ref="ss_plugin" v-model="ss.plugin" expanded>
-              <option value="">{{ $t("setting.options.off") }}</option>
+            <b-select v-model="ss.plugin" expanded required>
+              <option value="">Off</option>
               <option value="simple-obfs">simple-obfs</option>
               <option value="v2ray-plugin">v2ray-plugin</option>
             </b-select>
           </b-field>
-          <b-field v-if="ss.plugin === 'simple-obfs' || ss.plugin === 'v2ray-plugin'" label-position="on-border"
-            class="with-icon-alert">
-            <template slot="label">
-              Impl
-              <b-tooltip type="is-dark" :label="$t('setting.messages.ssPluginImpl')" multilined position="is-right">
-                <b-icon size="is-samll" icon=" iconfont icon-help-circle-outline" style="
-                    position: relative;
-                    top: 2px;
-                    right: 3px;
-                    font-weight: normal;
-                  " />
-              </b-tooltip>
-            </template>
-            <b-select ref="ss_plugin_impl" v-model="ss.impl" expanded>
-              <option value="">{{ $t("setting.options.default") }}</option>
-              <option value="chained">chained</option>
-              <option value="transport">transport</option>
-            </b-select>
-          </b-field>
-          <b-field v-show="ss.plugin === 'simple-obfs'" label="Obfs" label-position="on-border">
-            <b-select ref="ss_obfs" v-model="ss.obfs" expanded>
-              <option value="http">http</option>
-              <option value="tls">tls</option>
-            </b-select>
-          </b-field>
-          <b-field v-show="ss.plugin === 'v2ray-plugin'" label="Mode" label-position="on-border">
-            <b-select ref="ss_mode" v-model="ss.mode" expanded>
-              <option value="websocket">websocket</option>
-            </b-select>
-          </b-field>
-          <b-field v-show="ss.plugin === 'v2ray-plugin'" label="TLS" label-position="on-border">
-            <b-select ref="ss_tls" v-model="ss.tls" expanded>
-              <option value="">{{ $t("setting.options.off") }}</option>
-              <option value="tls">tls</option>
-            </b-select>
-          </b-field>
-          <b-field v-if="(ss.plugin === 'simple-obfs' &&
-            (ss.obfs === 'http' || ss.obfs === 'tls')) ||
-            ss.plugin === 'v2ray-plugin'
-          " label="Host" label-position="on-border">
-            <b-input ref="ss_host" v-model="ss.host" placeholder="(optional)" expanded />
-          </b-field>
-          <b-field v-if="(ss.plugin === 'simple-obfs' && ss.obfs === 'http') ||
-            ss.plugin === 'v2ray-plugin'
-          " label="Path" label-position="on-border">
-            <b-input ref="ss_path" v-model="ss.path" placeholder="/" expanded />
+          <b-field v-show="ss.plugin !== ''" label="Plugin Opts" label-position="on-border">
+            <b-input v-model="ss.plugin_opts" placeholder="obfs=http;obfs-host=www.baidu.com" expanded />
           </b-field>
           <b-field :label="$t('setting.nodeBackend')" label-position="on-border">
             <b-select v-model="ss.backend" expanded>
@@ -503,52 +335,40 @@ ref="v2ray_key" v-model="v2ray.key" :placeholder="$t('configureServer.password')
             </b-select>
           </b-field>
         </b-tab-item>
+
         <b-tab-item label="SSR">
           <b-field label="Name" label-position="on-border">
             <b-input ref="ssr_name" v-model="ssr.name" :placeholder="$t('configureServer.servername')" expanded />
           </b-field>
           <b-field label="Host" label-position="on-border">
-            <b-input ref="ssr_server" v-model="ssr.server" required placeholder="IP / HOST" expanded />
+            <b-input ref="ssr_server" required placeholder="IP / HOST" v-model="ssr.server" expanded />
           </b-field>
           <b-field label="Port" label-position="on-border">
-            <b-input ref="ssr_port" v-model="ssr.port" required :placeholder="$t('configureServer.port')" type="number"
+            <b-input ref="ssr_port" required :placeholder="$t('configureServer.port')" type="number" v-model="ssr.port"
               expanded />
           </b-field>
           <b-field label="Password" label-position="on-border">
-            <b-input ref="ssr_password" v-model="ssr.password" required :placeholder="$t('configureServer.password')"
+            <b-input ref="ssr_password" required :placeholder="$t('configureServer.password')" v-model="ssr.password"
               expanded />
           </b-field>
           <b-field label="Method" label-position="on-border">
-            <b-select ref="ssr_method" v-model="ssr.method" expanded required>
-              <option value="aes-128-cfb">aes-128-cfb</option>
-              <option value="aes-192-cfb">aes-192-cfb</option>
-              <option value="aes-256-cfb">aes-256-cfb</option>
+            <b-select v-model="ssr.method" expanded required>
               <option value="aes-128-ctr">aes-128-ctr</option>
               <option value="aes-192-ctr">aes-192-ctr</option>
               <option value="aes-256-ctr">aes-256-ctr</option>
-              <option value="aes-128-ofb">aes-128-ofb</option>
-              <option value="aes-192-ofb">aes-192-ofb</option>
-              <option value="aes-256-ofb">aes-256-ofb</option>
-              <option value="des-cfb">des-cfb</option>
-              <option value="bf-cfb">bf-cfb</option>
-              <option value="cast5-cfb">cast5-cfb</option>
+              <option value="aes-128-cfb">aes-128-cfb</option>
+              <option value="aes-192-cfb">aes-192-cfb</option>
+              <option value="aes-256-cfb">aes-256-cfb</option>
               <option value="rc4-md5">rc4-md5</option>
-              <option value="chacha20">chacha20</option>
               <option value="chacha20-ietf">chacha20-ietf</option>
+              <option value="chacha20">chacha20</option>
               <option value="salsa20">salsa20</option>
-              <option value="camellia-128-cfb">camellia-128-cfb</option>
-              <option value="camellia-192-cfb">camellia-192-cfb</option>
-              <option value="camellia-256-cfb">camellia-256-cfb</option>
-              <option value="idea-cfb">idea-cfb</option>
-              <option value="rc2-cfb">rc2-cfb</option>
-              <option value="seed-cfb">seed-cfb</option>
               <option value="none">none</option>
             </b-select>
           </b-field>
           <b-field label="Protocol" label-position="on-border">
-            <b-select ref="ssr_proto" v-model="ssr.proto" expanded required>
+            <b-select v-model="ssr.proto" expanded required>
               <option value="origin">origin</option>
-              <option value="verify_sha1">verify_sha1</option>
               <option value="auth_sha1_v4">auth_sha1_v4</option>
               <option value="auth_aes128_md5">auth_aes128_md5</option>
               <option value="auth_aes128_sha1">auth_aes128_sha1</option>
@@ -556,117 +376,51 @@ ref="v2ray_key" v-model="v2ray.key" :placeholder="$t('configureServer.password')
               <option value="auth_chain_b">auth_chain_b</option>
             </b-select>
           </b-field>
-          <b-field v-if="ssr.proto !== 'origin'" label="Protocol Param" label-position="on-border">
-            <b-input ref="ssr_protoParam" v-model="ssr.protoParam" placeholder="(optional)" expanded />
+          <b-field label="Protocol Param" label-position="on-border">
+            <b-input v-model="ssr.protoParam" expanded />
           </b-field>
           <b-field label="Obfs" label-position="on-border">
-            <b-select ref="ssr_obfs" v-model="ssr.obfs" expanded required>
+            <b-select v-model="ssr.obfs" expanded required>
               <option value="plain">plain</option>
               <option value="http_simple">http_simple</option>
               <option value="http_post">http_post</option>
-              <option value="random_head">random_head</option>
               <option value="tls1.2_ticket_auth">tls1.2_ticket_auth</option>
             </b-select>
           </b-field>
-          <b-field v-if="ssr.obfs !== 'plain'" label="Obfs Param" label-position="on-border">
-            <b-input ref="ssr_obfsParam" v-model="ssr.obfsParam" placeholder="(optional)" expanded />
+          <b-field label="Obfs Param" label-position="on-border">
+            <b-input v-model="ssr.obfsParam" expanded />
           </b-field>
         </b-tab-item>
+
         <b-tab-item label="Trojan">
           <b-field label="Name" label-position="on-border">
             <b-input ref="trojan_name" v-model="trojan.name" :placeholder="$t('configureServer.servername')" expanded />
           </b-field>
           <b-field label="Host" label-position="on-border">
-            <b-input ref="trojan_server" v-model="trojan.server" required placeholder="IP / HOST" expanded />
+            <b-input ref="trojan_server" required placeholder="IP / HOST" v-model="trojan.server" expanded />
           </b-field>
           <b-field label="Port" label-position="on-border">
-            <b-input ref="trojan_port" v-model="trojan.port" required :placeholder="$t('configureServer.port')"
-              type="number" expanded />
+            <b-input ref="trojan_port" required :placeholder="$t('configureServer.port')" type="number"
+              v-model="trojan.port" expanded />
           </b-field>
           <b-field label="Password" label-position="on-border">
-            <b-input ref="trojan_password" v-model="trojan.password" required
-              :placeholder="$t('configureServer.password')" expanded />
-          </b-field>
-          <b-field label="Protocol" label-position="on-border">
-            <b-select ref="trojan_method" v-model="trojan.method" expanded required>
-              <option value="origin">{{ $t("configureServer.origin") }}</option>
-              <option value="shadowsocks">shadowsocks</option>
-            </b-select>
-          </b-field>
-          <b-field v-if="trojan.method === 'shadowsocks'" label="Shadowsocks Cipher" label-position="on-border">
-            <b-select ref="trojan_ss_cipher" v-model="trojan.ssCipher" expanded required>
-              <option value="aes-128-gcm">aes-128-gcm</option>
-              <option value="aes-256-gcm">aes-256-gcm</option>
-              <option value="chacha20-poly1305">chacha20-poly1305</option>
-              <option value="chacha20-ietf-poly1305">
-                chacha20-ietf-poly1305
-              </option>
-            </b-select>
-          </b-field>
-          <b-field v-if="trojan.method === 'shadowsocks'" label="Shadowsocks Password" label-position="on-border">
-            <b-input ref="trojan_ss_password" v-model="trojan.ssPassword" required
-              :placeholder="`shadowsocks${$t('configureServer.password')}`" expanded />
+            <b-input ref="trojan_password" required :placeholder="$t('configureServer.password')"
+              v-model="trojan.password" expanded />
           </b-field>
           <b-field label-position="on-border">
-            <template slot="label">
-              AllowInsecure
-              <b-tooltip v-show="trojan.method !== 'origin' || trojan.obfs !== 'none'" type="is-dark" :label="$t('server.messages.notAllowInsecure', { name: 'Trojan-Go' })
-                " multilined position="is-right">
-                <b-icon size="is-small" icon=" iconfont icon-help-circle-outline" style="
-                    position: relative;
-                    top: 2px;
-                    right: 3px;
-                    font-weight: normal;
-                  " />
-              </b-tooltip>
-            </template>
+            <template slot="label"> AllowInsecure </template>
+            <b-tooltip v-show="trojan.method !== 'origin' || trojan.obfs !== 'none'" type="is-dark"
+              :label="$t('server.messages.notAllowInsecure', { name: 'Trojan-Go' })" multilined position="is-right">
+              <b-icon size="is-small" icon=" iconfont icon-help-circle-outline"
+                style="position: relative; top: 2px; right: 3px; font-weight: normal" />
+            </b-tooltip>
             <b-select ref="trojan_allow_insecure" v-model="trojan.allowInsecure" expanded required>
               <option :value="false">{{ $t("operations.no") }}</option>
-              <option :value="true" :disabled="trojan.method !== 'origin' || trojan.obfs !== 'none'">
-                {{ $t("operations.yes") }}
-              </option>
+              <option :value="true"> {{ $t("operations.yes") }} </option>
             </b-select>
           </b-field>
           <b-field label="SNI(Peer)" label-position="on-border">
             <b-input v-model="trojan.peer" placeholder="SNI(Peer)" expanded />
-          </b-field>
-          <b-field label="Network" label-position="on-border">
-            <b-select ref="trojan_net" v-model="trojan.net" expanded required @input="handleNetworkChange">
-              <option value="tcp">TCP</option>
-              <option value="kcp">mKCP</option>
-              <option value="ws">WebSocket</option>
-              <option value="h2">HTTP/2</option>
-              <option value="grpc">gRPC</option>
-            </b-select>
-          </b-field>
-          <b-field label="Obfs" label-position="on-border">
-            <b-select ref="trojan_obfs" v-model="trojan.obfs" expanded required>
-              <option value="none">
-                {{ $t("configureServer.noObfuscation") }}
-              </option>
-              <option value="websocket">websocket</option>
-            </b-select>
-          </b-field>
-          <b-field v-show="trojan.obfs === 'websocket'" label="Websocket Host" label-position="on-border">
-            <b-input v-model="trojan.host" expanded />
-          </b-field>
-          <b-field v-show="trojan.obfs === 'websocket'" label="Websocket Path" label-position="on-border">
-            <b-input v-model="trojan.path" placeholder="/" expanded />
-          </b-field>
-          <b-field v-show="trojan.net === 'ws' || trojan.net === 'h2'" label="Host" label-position="on-border">
-            <b-input v-model="trojan.host" :placeholder="$t('configureServer.hostObfuscation')" expanded />
-          </b-field>
-          <b-field v-show="trojan.tls === 'tls'" label="Alpn" label-position="on-border">
-            <b-input v-model="trojan.alpn" placeholder="h2,http/1.1" expanded />
-          </b-field>
-          <b-field v-show="trojan.net === 'ws' || trojan.net === 'h2'" label="Path" label-position="on-border">
-            <b-input v-model="trojan.path" :placeholder="$t('configureServer.pathObfuscation')" expanded />
-          </b-field>
-          <b-field v-show="trojan.net === 'mkcp' || trojan.net === 'kcp'" label="Seed" label-position="on-border">
-            <b-input v-model="trojan.path" :placeholder="$t('configureServer.seedObfuscation')" expanded />
-          </b-field>
-          <b-field v-show="trojan.net === 'grpc'" label="Service Name" label-position="on-border">
-            <b-input ref="trojan_service_name" v-model="trojan.path" type="text" expanded />
           </b-field>
           <b-field :label="$t('setting.nodeBackend')" label-position="on-border">
             <b-select v-model="trojan.backend" expanded>
@@ -682,18 +436,18 @@ ref="v2ray_key" v-model="v2ray.key" :placeholder="$t('configureServer.password')
               expanded />
           </b-field>
           <b-field label="Host" label-position="on-border">
-            <b-input ref="juicity_server" v-model="juicity.server" required placeholder="IP / HOST" expanded />
+            <b-input ref="juicity_server" required placeholder="IP / HOST" v-model="juicity.server" expanded />
           </b-field>
           <b-field label="Port" label-position="on-border">
-            <b-input ref="juicity_port" v-model="juicity.port" required :placeholder="$t('configureServer.port')"
-              type="number" expanded />
+            <b-input ref="juicity_port" required :placeholder="$t('configureServer.port')" type="number"
+              v-model="juicity.port" expanded />
           </b-field>
           <b-field label="UUID" label-position="on-border">
-            <b-input ref="juicity_uuid" v-model="juicity.uuid" required placeholder="UUID" expanded />
+            <b-input ref="juicity_uuid" required placeholder="UUID" v-model="juicity.uuid" expanded />
           </b-field>
           <b-field label="Password" label-position="on-border">
-            <b-input ref="juicity_password" v-model="juicity.password" required
-              :placeholder="$t('configureServer.password')" expanded />
+            <b-input ref="juicity_password" required :placeholder="$t('configureServer.password')"
+              v-model="juicity.password" expanded />
           </b-field>
           <b-field label="Congestion Control" label-position="on-border">
             <b-select ref="juicity_cc" v-model="juicity.cc" expanded required>
@@ -704,9 +458,7 @@ ref="v2ray_key" v-model="v2ray.key" :placeholder="$t('configureServer.password')
             <template slot="label"> AllowInsecure </template>
             <b-select ref="juicity_allow_insecure" v-model="juicity.allowInsecure" expanded required>
               <option :value="false">{{ $t("operations.no") }}</option>
-              <option :value="true">
-                {{ $t("operations.yes") }}
-              </option>
+              <option :value="true"> {{ $t("operations.yes") }} </option>
             </b-select>
           </b-field>
           <b-field label="SNI" label-position="on-border">
@@ -723,17 +475,17 @@ ref="v2ray_key" v-model="v2ray.key" :placeholder="$t('configureServer.password')
             <b-input ref="tuic_name" v-model="tuic.name" :placeholder="$t('configureServer.servername')" expanded />
           </b-field>
           <b-field label="Host" label-position="on-border">
-            <b-input ref="tuic_server" v-model="tuic.server" required placeholder="IP / HOST" expanded />
+            <b-input ref="tuic_server" required placeholder="IP / HOST" v-model="tuic.server" expanded />
           </b-field>
           <b-field label="Port" label-position="on-border">
-            <b-input ref="tuic_port" v-model="tuic.port" required :placeholder="$t('configureServer.port')"
-              type="number" expanded />
+            <b-input ref="tuic_port" required :placeholder="$t('configureServer.port')" type="number" v-model="tuic.port"
+              expanded />
           </b-field>
           <b-field label="UUID" label-position="on-border">
-            <b-input ref="tuic_uuid" v-model="tuic.uuid" required placeholder="UUID" expanded />
+            <b-input ref="tuic_uuid" required placeholder="UUID" v-model="tuic.uuid" expanded />
           </b-field>
           <b-field label="Password" label-position="on-border">
-            <b-input ref="tuic_password" v-model="tuic.password" required :placeholder="$t('configureServer.password')"
+            <b-input ref="tuic_password" required :placeholder="$t('configureServer.password')" v-model="tuic.password"
               expanded />
           </b-field>
           <b-field label="Congestion Control" label-position="on-border">
@@ -746,18 +498,14 @@ ref="v2ray_key" v-model="v2ray.key" :placeholder="$t('configureServer.password')
             <b-select v-if="tuic.disableSni === false" ref="tuic_allow_insecure" v-model="tuic.allowInsecure" expanded
               required>
               <option :value="false">{{ $t("operations.no") }}</option>
-              <option :value="true">
-                {{ $t("operations.yes") }}
-              </option>
+              <option :value="true"> {{ $t("operations.yes") }} </option>
             </b-select>
           </b-field>
           <b-field label-position="on-border">
             <template slot="label"> DisableSni </template>
             <b-select ref="tuic_disable_sni" v-model="tuic.disableSni" expanded required>
               <option :value="false">{{ $t("operations.no") }}</option>
-              <option :value="true">
-                {{ $t("operations.yes") }}
-              </option>
+              <option :value="true"> {{ $t("operations.yes") }} </option>
             </b-select>
           </b-field>
           <b-field v-if="tuic.disableSni === false" label="SNI" label-position="on-border">
@@ -781,23 +529,21 @@ ref="v2ray_key" v-model="v2ray.key" :placeholder="$t('configureServer.password')
               expanded />
           </b-field>
           <b-field label="Host" label-position="on-border">
-            <b-input ref="hysteria2_server" v-model="hysteria2.server" required placeholder="IP / HOST" expanded />
+            <b-input ref="hysteria2_server" required placeholder="IP / HOST" v-model="hysteria2.server" expanded />
           </b-field>
           <b-field label="Port" label-position="on-border">
-            <b-input ref="hysteria2_port" v-model="hysteria2.port" required :placeholder="$t('configureServer.port')"
-              type="number" expanded />
+            <b-input ref="hysteria2_port" required :placeholder="$t('configureServer.port')" type="number"
+              v-model="hysteria2.port" expanded />
           </b-field>
           <b-field label="Password" label-position="on-border">
-            <b-input ref="hysteria2_password" v-model="hysteria2.password" required
-              :placeholder="$t('configureServer.password')" expanded />
+            <b-input ref="hysteria2_password" required :placeholder="$t('configureServer.password')"
+              v-model="hysteria2.password" expanded />
           </b-field>
           <b-field label-position="on-border">
             <template slot="label"> AllowInsecure </template>
             <b-select ref="hysteria2_allow_insecure" v-model="hysteria2.allowInsecure" expanded required>
               <option :value="false">{{ $t("operations.no") }}</option>
-              <option :value="true">
-                {{ $t("operations.yes") }}
-              </option>
+              <option :value="true"> {{ $t("operations.yes") }} </option>
             </b-select>
           </b-field>
           <b-field label="SNI" label-position="on-border">
@@ -812,6 +558,31 @@ ref="v2ray_key" v-model="v2ray.key" :placeholder="$t('configureServer.password')
           <b-field v-if="hysteria2.obfs !== 'none'" label="Obfs Password" label-position="on-border">
             <b-input v-model="hysteria2.obfsPassword" placeholder="Obfs Password" expanded />
           </b-field>
+          <b-field label="Up Mbps" label-position="on-border">
+            <b-input v-model="hysteria2.up" placeholder="e.g. 100" expanded />
+          </b-field>
+          <b-field label="Down Mbps" label-position="on-border">
+            <b-input v-model="hysteria2.down" placeholder="e.g. 100" expanded />
+          </b-field>
+          <b-field label="Congestion" label-position="on-border">
+            <b-select v-model="hysteria2.congestion" expanded>
+              <option value="">default</option>
+              <option value="bbr">bbr</option>
+              <option value="cubic">cubic</option>
+            </b-select>
+          </b-field>
+          <b-field label-position="on-border">
+            <template slot="label">
+              FinalMask
+              <b-tooltip type="is-dark" :label="$t('server.messages.hysteria2FinalMaskInfo')" multilined position="is-right">
+                <b-icon size="is-small" icon=" iconfont icon-help-circle-outline"
+                  style="position: relative; top: 2px; right: 3px; font-weight: normal" />
+              </b-tooltip>
+            </template>
+            <b-checkbox v-model="hysteria2.finalMask">
+              Use native Xray implementation (requires Xray-core v26.1.23+)
+            </b-checkbox>
+          </b-field>
         </b-tab-item>
 
         <b-tab-item label="HTTP">
@@ -825,11 +596,11 @@ ref="v2ray_key" v-model="v2ray.key" :placeholder="$t('configureServer.password')
             <b-input ref="http_name" v-model="http.name" :placeholder="$t('configureServer.servername')" expanded />
           </b-field>
           <b-field label="Host" label-position="on-border">
-            <b-input ref="http_host" v-model="http.host" required placeholder="IP / HOST" expanded />
+            <b-input ref="http_host" required placeholder="IP / HOST" v-model="http.host" expanded />
           </b-field>
           <b-field label="Port" label-position="on-border">
-            <b-input ref="http_port" v-model="http.port" required :placeholder="$t('configureServer.port')"
-              type="number" expanded />
+            <b-input ref="http_port" required :placeholder="$t('configureServer.port')" type="number" v-model="http.port"
+              expanded />
           </b-field>
           <b-field label="Username" label-position="on-border">
             <b-input ref="http_username" v-model="http.username" :placeholder="$t('configureServer.username')"
@@ -840,17 +611,16 @@ ref="v2ray_key" v-model="v2ray.key" :placeholder="$t('configureServer.password')
               expanded />
           </b-field>
         </b-tab-item>
-
         <b-tab-item label="SOCKS5">
           <b-field label="Name" label-position="on-border">
             <b-input ref="socks5_name" v-model="socks5.name" :placeholder="$t('configureServer.servername')" expanded />
           </b-field>
           <b-field label="Host" label-position="on-border">
-            <b-input ref="socks5_host" v-model="socks5.host" required placeholder="IP / HOST" expanded />
+            <b-input ref="socks5_host" required placeholder="IP / HOST" v-model="socks5.host" expanded />
           </b-field>
           <b-field label="Port" label-position="on-border">
-            <b-input ref="socks5_port" v-model="socks5.port" required :placeholder="$t('configureServer.port')"
-              type="number" expanded />
+            <b-input ref="socks5_port" required :placeholder="$t('configureServer.port')" type="number" v-model="socks5.port"
+              expanded />
           </b-field>
           <b-field label="Username" label-position="on-border">
             <b-input ref="socks5_username" v-model="socks5.username" :placeholder="$t('configureServer.username')"
@@ -861,22 +631,22 @@ ref="v2ray_key" v-model="v2ray.key" :placeholder="$t('configureServer.password')
               expanded />
           </b-field>
         </b-tab-item>
-
         <b-tab-item label="AnyTLS">
           <b-field label="Name" label-position="on-border">
             <b-input ref="anytls_name" v-model="anytls.name" :placeholder="$t('configureServer.servername')" expanded />
           </b-field>
           <b-field label="Host" label-position="on-border">
-            <b-input ref="anytls_host" v-model="anytls.host" required placeholder="IP / HOST" expanded />
+            <b-input ref="anytls_host" required placeholder="IP / HOST" v-model="anytls.host" expanded />
           </b-field>
           <b-field label="Port" label-position="on-border">
-            <b-input ref="anytls_port" v-model="anytls.port" required :placeholder="$t('configureServer.port')" type="number" expanded />
+            <b-input ref="anytls_port" required :placeholder="$t('configureServer.port')" type="number" v-model="anytls.port"
+              expanded />
           </b-field>
           <b-field label="Auth" label-position="on-border">
-            <b-input ref="anytls_auth" v-model="anytls.auth" required placeholder="Authentication Key" expanded />
+            <b-input ref="anytls_auth" required placeholder="Authentication Key" v-model="anytls.auth" expanded />
           </b-field>
           <b-field label="SNI(Peer)" label-position="on-border">
-            <b-input ref="anytls_sni" v-model="anytls.sni" placeholder="SNI / Peer (Optional)" expanded />
+            <b-input ref="anytls_sni" placeholder="SNI / Peer (Optional)" v-model="anytls.sni" expanded />
           </b-field>
           <b-field label-position="on-border">
             <template slot="label"> AllowInsecure </template>
@@ -888,11 +658,11 @@ ref="v2ray_key" v-model="v2ray.key" :placeholder="$t('configureServer.password')
         </b-tab-item>
       </b-tabs>
     </section>
-    <footer v-if="!readonly" class="modal-card-foot flex-end">
+    <footer class="modal-card-foot flex-end">
       <button class="button" type="button" @click="$parent.close()">
         {{ $t("operations.cancel") }}
       </button>
-      <button class="button is-primary" @click="handleClickSubmit">
+      <button v-if="!readonly" class="button is-primary" @click="handleClickSubmit">
         {{ $t("operations.saveApply") }}
       </button>
     </footer>
@@ -900,193 +670,193 @@ ref="v2ray_key" v-model="v2ray.key" :placeholder="$t('configureServer.password')
 </template>
 
 <script>
-import { generateURL, handleResponse, parseURL } from "@/assets/js/utils";
+import { bracketIfIPv6, generateURL, handleResponse, parseURL } from "@/assets/js/utils";
 import { Base64 } from "js-base64";
+import { Decoder } from "@nuintun/qrcode";
 
 export default {
   name: "ModalServer",
   props: {
-    which: {
-      type: Object,
-      default() {
-        return null;
-      },
-    },
     readonly: {
       type: Boolean,
       default: false,
     },
+    which: {
+      type: Object,
+      default: () => ({}),
+    },
   },
-  data: () => ({
-    vlessVersion: 0,
-    v2ray: {
-      ps: "",
-      add: "",
-      port: "",
-      id: "",
-      flow: "",
-      aid: "",
-      net: "tcp",
-      type: "none",
-      host: "",
-      path: "",
-      tls: "none",
-      quicSecurity: "none",
-      fp: "",
-      pbk: "",
-      sid: "",
-      spx: "",
-      alpn: "",
-      scy: "auto",
-      v: "",
-      allowInsecure: false,
-      protocol: "vmess",
-      key: "none",
-      xhttpMode: "auto",
-      xhttpRawJson: "",
-      maxEarlyData: "",
-      earlyDataHeaderName: "",
-      multiMode: false,
-      idleTimeout: "",
-      healthCheckTimeout: "",
-      permitWithoutStream: false,
-      initialWindowsSize: "",
-    },
-    ss: {
-      method: "2022-blake3-aes-128-gcm",
-      plugin: "",
-      obfs: "http",
-      tls: "",
-      path: "/",
-      mode: "websocket",
-      host: "",
-      password: "",
-      server: "",
-      port: "",
-      name: "",
-      protocol: "ss",
-      impl: "",
-      backend: "",
-    },
-    ssr: {
-      method: "aes-128-cfb",
-      password: "",
-      server: "",
-      port: "",
-      name: "",
-      proto: "origin",
-      protoParam: "",
-      obfs: "plain",
-      obfsParam: "",
-      protocol: "ssr",
-    },
-    trojan: {
-      name: "",
-      server: "",
-      peer: "" /* tls sni */,
-      host: "" /* websocket host */,
-      path: "" /* websocket path */,
-      allowInsecure: false,
-      port: "",
-      password: "",
-      method: "origin" /* shadowsocks */,
-      ssCipher: "aes-128-gcm",
-      ssPassword: "",
-      net: "tcp",
-      obfs: "none" /* websocket */,
-      protocol: "trojan",
-      backend: "",
-    },
-    juicity: {
-      name: "",
-      server: "",
-      port: "",
-      sni: "",
-      cc: "bbr",
-      uuid: "",
-      password: "",
-      pinnedCertchainSha256: "",
-      allowInsecure: false,
-      protocol: "juicity",
-    },
-    tuic: {
-      name: "",
-      server: "",
-      port: "",
-      sni: "",
-      cc: "bbr",
-      uuid: "",
-      password: "",
-      allowInsecure: false,
-      disableSni: false,
-      alpn: "h3",
-      udpRelayMode: "native",
-      protocol: "tuic",
-    },
-    hysteria2: {
-      name: "",
-      server: "",
-      port: "",
-      password: "",
-      sni: "",
-      obfs: "none",
-      obfsPassword: "",
-      allowInsecure: false,
-      protocol: "hysteria2",
-    },
-    http: {
-      username: "",
-      password: "",
-      host: "",
-      port: "",
-      protocol: "http",
-      name: "",
-    },
-    socks5: {
-      username: "",
-      password: "",
-      host: "",
-      port: "",
-      protocol: "socks5",
-      name: "",
-    },
-    anytls: {
-      name: "",
-      host: "",
-      port: "",
-      auth: "",
-      sni: "",
-      allowInsecure: false,
-      protocol: "anytls",
-    },
-    wireguard: {
-      name: "",
-      address: "",
-      port: "",
-      publicKey: "",
-      privateKey: "",
-      localAddress: "",
-      dns: "",
-      mtu: "",
-      allowedIPs: "",
-      persistentKeepalive: "",
-      preSharedKey: "",
-      endpoint: "",
-    },
-    tabChoice: 0,
-  }),
+  data() {
+    return {
+      tabChoice: 0,
+      v2ray: {
+        ps: "",
+        add: "",
+        port: "",
+        id: "",
+        flow: "",
+        aid: "",
+        net: "tcp",
+        type: "none",
+        host: "",
+        path: "",
+        tls: "none",
+        quicSecurity: "none",
+        fp: "",
+        pbk: "",
+        sid: "",
+        spx: "",
+        alpn: "",
+        scy: "auto",
+        v: "",
+        allowInsecure: false,
+        protocol: "vmess",
+        key: "none",
+        xhttpMode: "auto",
+        xhttpRawJson: "",
+        maxEarlyData: "",
+        earlyDataHeaderName: "",
+        multiMode: false,
+        idleTimeout: "",
+        healthCheckTimeout: "",
+        permitWithoutStream: false,
+        initialWindowsSize: "",
+      },
+      ss: {
+        name: "",
+        server: "",
+        port: "",
+        password: "",
+        method: "chacha20-ietf-poly1305",
+        plugin: "",
+        plugin_opts: "",
+        protocol: "ss",
+        backend: "",
+      },
+      ssr: {
+        server: "",
+        port: "",
+        proto: "origin",
+        method: "aes-128-ctr",
+        obfs: "plain",
+        password: "",
+        name: "",
+        protoParam: "",
+        obfsParam: "",
+        protocol: "ssr",
+      },
+      trojan: {
+        password: "",
+        server: "",
+        port: "",
+        allowInsecure: false,
+        peer: "",
+        name: "",
+        protocol: "trojan",
+        backend: "",
+      },
+      juicity: {
+        uuid: "",
+        password: "",
+        server: "",
+        port: "",
+        cc: "bbr",
+        allowInsecure: false,
+        sni: "",
+        pinnedCertchainSha256: "",
+        name: "",
+        protocol: "juicity",
+      },
+      tuic: {
+        uuid: "",
+        password: "",
+        server: "",
+        port: "",
+        cc: "bbr",
+        allowInsecure: false,
+        disableSni: false,
+        sni: "",
+        alpn: "h3",
+        udpRelayMode: "native",
+        name: "",
+        protocol: "tuic",
+      },
+      hysteria2: {
+        password: "",
+        server: "",
+        port: "",
+        allowInsecure: false,
+        obfs: "none",
+        obfsPassword: "",
+        sni: "",
+        up: "",
+        down: "",
+        congestion: "",
+        finalMask: false,
+        name: "",
+        protocol: "hysteria2",
+      },
+      http: {
+        protocol: "http",
+        name: "",
+        host: "",
+        port: "",
+        username: "",
+        password: "",
+      },
+      socks5: {
+        name: "",
+        host: "",
+        port: "",
+        username: "",
+        password: "",
+      },
+      anytls: {
+        auth: "",
+        host: "",
+        port: "",
+        sni: "",
+        allowInsecure: false,
+        name: "",
+        protocol: "anytls",
+      },
+      wireguard: {
+        name: "",
+        address: "",
+        port: "",
+        publicKey: "",
+        privateKey: "",
+        localAddress: "",
+        dns: "",
+        mtu: "",
+        allowedIPs: "",
+        persistentKeepalive: "",
+        preSharedKey: "",
+        endpoint: "",
+      },
+    };
+  },
   mounted() {
-    if (this.which !== null) {
+    document
+      .querySelector("#QRCodeImport")
+      .addEventListener("change", this.handleFileChange, false);
+    if (this.which) {
       this.$axios({
         url: apiRoot + "/sharingAddress",
         method: "get",
         params: {
-          touch: this.which,
+          touch: {
+            id: this.which.id,
+            _type: this.which._type,
+            sub: this.which.sub,
+          },
         },
       }).then((res) => {
         handleResponse(res, this, () => {
-          if (
-            res.data.data.sharingAddress.toLowerCase().startsWith("vmess://") ||
+          if (res.data.data.sharingAddress.toLowerCase().startsWith("vmess://")) {
+            this.v2ray = this.resolveURL(res.data.data.sharingAddress);
+            this.tabChoice = 0;
+          } else if (
             res.data.data.sharingAddress.toLowerCase().startsWith("vless://")
           ) {
             this.v2ray = this.resolveURL(res.data.data.sharingAddress);
@@ -1107,12 +877,7 @@ export default {
             this.ssr = this.resolveURL(res.data.data.sharingAddress);
             this.tabChoice = 3;
           } else if (
-            res.data.data.sharingAddress
-              .toLowerCase()
-              .startsWith("trojan://") ||
-            res.data.data.sharingAddress
-              .toLowerCase()
-              .startsWith("trojan-go://")
+            res.data.data.sharingAddress.toLowerCase().startsWith("trojan://")
           ) {
             this.trojan = this.resolveURL(res.data.data.sharingAddress);
             this.tabChoice = 4;
@@ -1134,7 +899,9 @@ export default {
             this.tabChoice = 7;
           } else if (
             res.data.data.sharingAddress.toLowerCase().startsWith("http://") ||
-            res.data.data.sharingAddress.toLowerCase().startsWith("https://")
+            res.data.data.sharingAddress.toLowerCase().startsWith("https://") ||
+            res.data.data.sharingAddress.toLowerCase().startsWith("http-proxy://") ||
+            res.data.data.sharingAddress.toLowerCase().startsWith("https-proxy://")
           ) {
             this.http = this.resolveURL(res.data.data.sharingAddress);
             this.tabChoice = 8;
@@ -1153,14 +920,10 @@ export default {
             if (this.readonly) {
               this.$refs.section
                 .querySelectorAll("input, textarea")
-                .forEach((x) => (x.readOnly = "readOnly"));
-              this.$refs.section.querySelectorAll("select").forEach((x) => {
-                const text = x.querySelector(
-                  `option[value="${x.value}"]`
-                ).textContent;
-                console.log(x.value, text);
-                x.outerHTML = `<input type="text" class="input" readonly="readonly" value="${text}">`;
-              });
+                .forEach((x) => (x.disabled = true));
+              this.$refs.section
+                .querySelectorAll("select")
+                .forEach((x) => (x.parentNode.className += " is-disabled"));
             }
           });
         });
@@ -1176,39 +939,67 @@ export default {
         this.v2ray.scy = "none";
       }
     },
+    handleNetworkChange() {
+      this.v2ray.type = "none";
+      if (this.v2ray.tls === "none" && this.v2ray.net === "grpc") {
+        this.$buefy.toast.open({
+          message: this.$t("setting.messages.grpcShouldWithTls"),
+          type: "is-warning",
+          position: "is-top",
+          queue: false,
+          duration: 5000,
+        });
+        this.$nextTick(() => {
+          this.v2ray.tls = "tls";
+        });
+      }
+    },
     resolveURL(url) {
       if (url.toLowerCase().startsWith("vmess://")) {
         let obj = JSON.parse(
           Base64.decode(url.substring(url.indexOf("://") + 3))
         );
-        // console.log(obj);
-        obj.ps = decodeURIComponent(obj.ps);
-        obj.tls = obj.tls || "none";
-        obj.type = obj.type || "none";
-        obj.scy = obj.scy || "auto";
-        obj.protocol = obj.protocol || "vmess";
-        return obj;
+        console.log(obj);
+        return {
+          ps: obj.ps,
+          add: obj.add,
+          port: obj.port,
+          id: obj.id,
+          aid: obj.aid,
+          scy: obj.scy,
+          net: obj.net,
+          type: obj.type,
+          host: obj.host,
+          path: obj.path,
+          tls: obj.tls,
+          allowInsecure: obj.allowInsecure || false,
+          key: obj.key,
+          quicSecurity: obj.quicSecurity,
+          xhttpMode: obj.xhttpMode || "auto",
+          xhttpRawJson: obj.xhttpRawJson || "",
+          protocol: "vmess",
+        };
       } else if (url.toLowerCase().startsWith("vless://")) {
         let u = parseURL(url);
-        const o = {
+        let o = {
           ps: decodeURIComponent(u.hash),
           add: u.host,
           port: u.port,
-          id: decodeURIComponent(u.username),
-          flow: u.params.flow || "",
+          id: u.username ? decodeURIComponent(u.username) : "",
           net: u.params.type || "tcp",
           type: u.params.headerType || "none",
           host: u.params.host || "",
           path: u.params.path || u.params.serviceName || "",
           alpn: u.params.alpn || "",
           sni: u.params.sni || "",
-          tls: u.params.security || u.params.tls || "none",
+          tls: u.params.security || "none",
           quicSecurity: u.params.quicSecurity || "none",
           fp: u.params.fp || "",
           pbk: u.params.pbk || "",
           sid: u.params.sid || "",
           spx: u.params.spx || "",
-          allowInsecure: u.params.allowInsecure || false,
+          allowInsecure: u.params.allowInsecure === "true",
+          flow: u.params.flow || u.params.flows || "",
           scy: u.params.encryption || "none",
           key: u.params.key,
           xhttpMode: u.params.xhttpMode || "auto",
@@ -1222,9 +1013,6 @@ export default {
           initialWindowsSize: u.params.initialWindowsSize || "",
           protocol: "vless",
         };
-        if (o.alpn !== "") {
-          o.alpn = decodeURIComponent(o.alpn);
-        }
         if (o.net === "mkcp" || o.net === "kcp") {
           o.path = u.params.seed;
         }
@@ -1232,129 +1020,117 @@ export default {
         return o;
       } else if (url.toLowerCase().startsWith("ss://")) {
         let u = parseURL(url);
-        let userinfo = u.username;
-        // Handle SIP002 format: ss://BASE64URL@host:port vs legacy ss://BASE64
-        let method = "", password = "";
-        try {
-          let decoded = Base64.decode(userinfo);
-          let idx = decoded.indexOf(":");
-          if (idx > -1) {
-            method = decoded.substring(0, idx);
-            password = decoded.substring(idx + 1);
-          }
-        } catch (e) {
-          method = userinfo;
+        let method, password, server, port, name, plugin;
+        name = u.hash;
+        plugin = u.params.plugin || "";
+        if (u.username) {
+          // SIP002
+          let parts = Base64.decode(decodeURIComponent(u.username)).split(":");
+          method = parts[0];
+          password = parts.slice(1).join(":");
+          server = u.host;
+          port = u.port;
+        } else {
+          // Legacy
+          let t = url.substring(url.indexOf("://") + 3);
+          if (t.indexOf("#") > -1) t = t.substring(0, t.indexOf("#"));
+          let decoded = Base64.decode(t);
+          let parts = decoded.split("@");
+          let methodAndPassword = parts[0].split(":");
+          method = methodAndPassword[0];
+          password = methodAndPassword[1];
+          let serverAndPort = parts[1].split(":");
+          server = serverAndPort[0];
+          port = serverAndPort[1];
         }
-        const ssPlugin = u.params.plugin || "";
         return {
-          method: method,
-          password: password,
-          server: u.host,
-          port: u.port,
-          name: decodeURIComponent(u.hash || ""),
-          plugin: ssPlugin.split(";")[0] || "",
-          plugin_opts: ssPlugin.split(";").slice(1).join(";") || "",
+          method,
+          password,
+          server,
+          port,
+          name,
+          plugin,
           protocol: "ss",
           backend: u.params["v2raya-backend"] || "",
         };
       } else if (url.toLowerCase().startsWith("ssr://")) {
-        url = Base64.decode(url.substr(6));
+        let t = url.substring(6);
+        if (t.indexOf("#") > -1) t = t.substring(0, t.indexOf("#"));
+        url = Base64.decode(t);
         let arr = url.split("/?");
-        let query = arr[1].split("&");
-        let m = {};
-        for (let param of query) {
-          let [key, val] = param.split("=", 2);
-          val = Base64.decode(val);
-          m[key] = val;
-        }
         let pre = arr[0].split(":");
         if (pre.length > 6) {
           //如果长度多于6，说明host中包含字符:，重新合并前几个分组到host去
           pre[pre.length - 6] = pre.slice(0, pre.length - 5).join(":");
           pre = pre.slice(pre.length - 6);
         }
-        pre[5] = Base64.decode(pre[5]);
+        let query = {};
+        if (arr[1]) {
+          arr[1].split("&").forEach((x) => {
+            let a = x.split("=");
+            if (a.length > 1 && a[1]) {
+              query[a[0]] = Base64.decode(a[1]);
+            } else {
+              query[a[0]] = "";
+            }
+          });
+        }
         return {
-          method: pre[3],
-          password: pre[5],
           server: pre[0],
           port: pre[1],
-          name: m["remarks"],
           proto: pre[2],
-          protoParam: m["protoparam"],
+          method: pre[3],
           obfs: pre[4],
-          obfsParam: m["obfsparam"],
+          password: Base64.decode(pre[5]),
+          name: query.remarks,
+          protoParam: query.protoparam,
+          obfsParam: query.obfsparam,
           protocol: "ssr",
         };
-      } else if (
-        url.toLowerCase().startsWith("trojan://") ||
-        url.toLowerCase().startsWith("trojan-go://")
-      ) {
+      } else if (url.toLowerCase().startsWith("trojan://")) {
         let u = parseURL(url);
-        const o = {
+        return {
           password: decodeURIComponent(u.username),
           server: u.host,
           port: u.port,
+          allowInsecure: u.params.allowInsecure === "1",
+          peer: u.params.sni || "",
           name: decodeURIComponent(u.hash),
-          peer: u.params.peer || u.params.sni || "",
-          allowInsecure:
-            u.params.allowInsecure === "true" || u.params.allowInsecure === "1",
-          method: "origin",
-          net: u.params.type || "tcp",
-          obfs: "none",
-          ssCipher: "2022-blake3-aes-128-gcm",
-          path: u.params.path || u.params.serviceName || "",
           protocol: "trojan",
           backend: u.params["v2raya-backend"] || "",
         };
-        if (url.toLowerCase().startsWith("trojan-go://")) {
-          console.log(u.params.encryption);
-          if (u.params.encryption?.startsWith("ss;")) {
-            o.method = "shadowsocks";
-            const fields = u.params.encryption.split(";");
-            o.ssCipher = fields[1];
-            o.ssPassword = fields[2];
-          }
-          if (u.params.type === "ws") {
-            o.obfs = "websocket";
-            o.host = u.params.host || "";
-            o.path = u.params.path || "/";
-          }
-        }
-        return o;
       } else if (url.toLowerCase().startsWith("juicity://")) {
         let u = parseURL(url);
+        let password = decodeURIComponent(u.password);
+        let uuid = decodeURIComponent(u.username);
         return {
-          name: decodeURIComponent(u.hash),
-          uuid: decodeURIComponent(u.username),
-          password: decodeURIComponent(u.password),
+          uuid: uuid,
+          password: password,
           server: u.host,
           port: u.port,
-          sni: u.params.sni || "",
-          allowInsecure:
-            u.params.allow_insecure === "true" ||
-            u.params.allow_insecure === "1",
-          pinnedCertchainSha256: u.params.pinned_certchain_sha256 || "",
           cc: u.params.congestion_control || "bbr",
+          allowInsecure: u.params.allow_insecure === "1",
+          sni: u.params.sni || "",
+          pinnedCertchainSha256: u.params.pinned_certchain_sha256 || "",
+          name: decodeURIComponent(u.hash),
           protocol: "juicity",
         };
       } else if (url.toLowerCase().startsWith("tuic://")) {
         let u = parseURL(url);
+        let password = decodeURIComponent(u.password);
+        let uuid = decodeURIComponent(u.username);
         return {
-          name: decodeURIComponent(u.hash),
-          uuid: decodeURIComponent(u.username),
-          password: decodeURIComponent(u.password),
+          uuid: uuid,
+          password: password,
           server: u.host,
           port: u.port,
-          sni: u.params.sni || "",
-          allowInsecure:
-            u.params.allow_insecure === "true" ||
-            u.params.allow_insecure === "1",
-          disableSni:
-            u.params.disable_sni === "true" || u.params.disable_sni === "1",
-          alpn: u.params.alpn,
           cc: u.params.congestion_control || "bbr",
+          allowInsecure: u.params.allow_insecure === "1",
+          disableSni: u.params.disable_sni === "1",
+          sni: u.params.sni || "",
+          alpn: u.params.alpn || "h3",
           udpRelayMode: u.params.udp_relay_mode || "native",
+          name: decodeURIComponent(u.hash),
           protocol: "tuic",
         };
       } else if (
@@ -1363,19 +1139,25 @@ export default {
       ) {
         let u = parseURL(url);
         return {
-          name: decodeURIComponent(u.hash),
           password: decodeURIComponent(u.username),
           server: u.host,
           port: u.port,
-          sni: u.params.sni || "",
-          allowInsecure: u.params.insecure === "true" || u.params.insecure === "1",
+          allowInsecure: u.params.insecure === "1",
           obfs: u.params.obfs || "none",
           obfsPassword: u.params["obfs-password"] || "",
+          sni: u.params.sni || "",
+          up: u.params.upmbps || "",
+          down: u.params.downmbps || "",
+          congestion: u.params.congestion || "",
+          finalMask: u.params.finalmask === "1",
+          name: decodeURIComponent(u.hash),
           protocol: "hysteria2",
         };
       } else if (
         url.toLowerCase().startsWith("http://") ||
-        url.toLowerCase().startsWith("https://")
+        url.toLowerCase().startsWith("https://") ||
+        url.toLowerCase().startsWith("http-proxy://") ||
+        url.toLowerCase().startsWith("https-proxy://")
       ) {
         let u = parseURL(url);
         return {
@@ -1383,7 +1165,7 @@ export default {
           password: decodeURIComponent(u.password),
           host: u.host,
           port: u.port,
-          protocol: u.protocol,
+          protocol: u.protocol.replace("-proxy", ""),
           name: decodeURIComponent(u.hash),
         };
       } else if (url.toLowerCase().startsWith("socks5://")) {
@@ -1432,13 +1214,33 @@ export default {
     generateURL(srcObj) {
       let obj = {};
       let query = {};
-      let tmp;
+      let tmp = "";
       switch (srcObj.protocol) {
+        case "vmess":
+          obj = {
+            v: "2",
+            ps: srcObj.ps,
+            add: srcObj.add,
+            port: srcObj.port,
+            id: srcObj.id,
+            aid: srcObj.aid,
+            scy: srcObj.scy,
+            net: srcObj.net,
+            type: srcObj.type,
+            host: srcObj.host,
+            path: srcObj.path,
+            tls: srcObj.tls,
+            allowInsecure: srcObj.allowInsecure,
+            key: srcObj.key,
+            quicSecurity: srcObj.quicSecurity,
+            xhttpMode: srcObj.xhttpMode,
+            xhttpRawJson: srcObj.xhttpRawJson,
+          };
+          return "vmess://" + Base64.encode(JSON.stringify(obj));
         case "vless":
-          // todo: support reality and xhttp
-          // https://github.com/XTLS/Xray-core/discussions/716
           query = {
             type: srcObj.net,
+            flow: srcObj.flow || "",
             security: srcObj.tls,
             fp: srcObj.fp || "",
             path: srcObj.path,
@@ -1447,12 +1249,6 @@ export default {
             sni: srcObj.sni,
             allowInsecure: srcObj.allowInsecure,
           };
-          if (srcObj.flow && srcObj.flow !== "none") {
-            query.flow = srcObj.flow;
-          }
-          if (srcObj.scy && srcObj.scy !== "none") {
-            query.encryption = srcObj.scy;
-          }
           if (srcObj.alpn !== "") {
             query.alpn = srcObj.alpn;
           }
@@ -1482,6 +1278,11 @@ export default {
               query.initialWindowsSize = srcObj.initialWindowsSize;
             }
           }
+          if (srcObj.tls === "reality") {
+            query.pbk = srcObj.pbk;
+            query.sid = srcObj.sid;
+            query.spx = srcObj.spx || "/";
+          }
           if (srcObj.net === "mkcp" || srcObj.net === "kcp") {
             query.seed = srcObj.path;
           }
@@ -1491,14 +1292,9 @@ export default {
           }
           if (srcObj.net === "xhttp") {
             query.xhttpMode = srcObj.xhttpMode;
-            if (srcObj.xhttpRawJson) {
+            if (srcObj.xhttpMode === "packet") {
               query.xhttpRawJson = srcObj.xhttpRawJson;
             }
-          }
-          if (query.security == "reality") {
-            query.pbk = srcObj.pbk;
-            query.sid = srcObj.sid;
-            query.spx = srcObj.spx;
           }
           return generateURL({
             protocol: "vless",
@@ -1508,37 +1304,9 @@ export default {
             hash: srcObj.ps,
             params: query,
           });
-        case "vmess":
-          //https://github.com/2dust/v2rayN/wiki/%E5%88%86%E4%BA%AB%E9%93%BE%E6%8E%A5%E6%A0%BC%E5%BC%8F%E8%AF%B4%E6%98%8E(ver-2)
-          obj = Object.assign({}, srcObj);
-          switch (obj.net) {
-            case "kcp":
-            case "tcp":
-            case "quic":
-              break;
-            default:
-              obj.type = "";
-          }
-          switch (obj.net) {
-            case "ws":
-            case "h2":
-            case "http":
-            case "quic":
-            case "grpc":
-            case "kcp":
-            case "mkcp":
-              break;
-            default:
-              if (obj.net === "tcp" && obj.type === "http") {
-                break;
-              }
-              obj.path = "";
-          }
-          return "vmess://" + Base64.encode(JSON.stringify(obj));
         case "ss":
           /* ss://BASE64(method:password)@server:port#name */
-          tmp = `ss://${Base64.encode(`${srcObj.method}:${srcObj.password}`)}@${srcObj.server
-            }:${srcObj.port}/`;
+          tmp = `ss://${Base64.encode(`${srcObj.method}:${srcObj.password}`)}@${bracketIfIPv6(srcObj.server)}:${srcObj.port}`;
           if (srcObj.plugin) {
             const plugin = [srcObj.plugin];
             if (srcObj.plugin === "v2ray-plugin") {
@@ -1572,15 +1340,16 @@ export default {
             }
             tmp += `?plugin=${encodeURIComponent(plugin.join(";"))}`;
           }
-          tmp += srcObj.name.length
-            ? `#${encodeURIComponent(srcObj.name)}`
-            : "";
+          if (srcObj.backend) {
+            tmp += (tmp.includes("?") ? "&" : "?") + `v2raya-backend=${encodeURIComponent(srcObj.backend)}`;
+          }
+          tmp += srcObj.name.length ? `#${encodeURIComponent(srcObj.name)}` : "";
           return tmp;
 
         case "ssr":
           /* ssr://server:port:proto:method:obfs:URLBASE64(password)/?remarks=URLBASE64(remarks)&protoparam=URLBASE64(protoparam)&obfsparam=URLBASE64(obfsparam)) */
           return `ssr://${Base64.encode(
-            `${srcObj.server}:${srcObj.port}:${srcObj.proto}:${srcObj.method}:${srcObj.obfs
+            `${bracketIfIPv6(srcObj.server)}:${srcObj.port}:${srcObj.proto}:${srcObj.method}:${srcObj.obfs
             }:${Base64.encodeURI(srcObj.password)}/?remarks=${Base64.encodeURI(
               srcObj.name
             )}&protoparam=${Base64.encodeURI(
@@ -1590,37 +1359,17 @@ export default {
         case "trojan":
           /* trojan://password@server:port?allowInsecure=1&sni=sni#URIESCAPE(name) */
           query = {
-            type: srcObj.net,
-            allowInsecure: srcObj.allowInsecure,
+            type: srcObj.net || "tcp",
+            allowInsecure: srcObj.allowInsecure ? "1" : "0",
           };
           if (srcObj.peer !== "") {
             query.sni = srcObj.peer;
           }
-          tmp = "trojan";
-          if (srcObj.method !== "origin" || srcObj.obfs !== "none") {
-            tmp = "trojan-go";
-            query.type = srcObj.obfs === "none" ? "original" : "ws";
-            if (srcObj.method === "shadowsocks") {
-              query.encryption = `ss;${srcObj.ssCipher};${srcObj.ssPassword}`;
-            }
-            if (query.type === "ws") {
-              query.host = srcObj.host || "";
-              query.path = srcObj.path || "/";
-            }
-            delete query.allowInsecure;
-          }
-
-          if (srcObj.alpn !== "") {
-            query.alpn = srcObj.alpn;
-          }
-          if (srcObj.net === "grpc") {
-            query.serviceName = srcObj.path;
-          }
-          if (srcObj.net === "mkcp" || srcObj.net === "kcp") {
-            query.seed = srcObj.path;
+          if (srcObj.backend) {
+            query["v2raya-backend"] = srcObj.backend;
           }
           return generateURL({
-            protocol: tmp,
+            protocol: "trojan",
             username: srcObj.password,
             host: srcObj.server,
             port: srcObj.port,
@@ -1629,7 +1378,7 @@ export default {
           });
         case "juicity":
           query = {
-            allow_insecure: srcObj.allowInsecure,
+            allow_insecure: srcObj.allowInsecure ? "1" : "0",
             congestion_control: srcObj.cc,
           };
           if (srcObj.sni !== "") {
@@ -1649,9 +1398,9 @@ export default {
           });
         case "tuic":
           query = {
-            allow_insecure: srcObj.allowInsecure,
+            allow_insecure: srcObj.allowInsecure ? "1" : "0",
             congestion_control: srcObj.cc,
-            disable_sni: srcObj.disableSni,
+            disable_sni: srcObj.disableSni ? "1" : "0",
             alpn: srcObj.alpn,
             udp_relay_mode: srcObj.udpRelayMode,
           };
@@ -1678,6 +1427,10 @@ export default {
             query.obfs = srcObj.obfs;
             query["obfs-password"] = srcObj.obfsPassword;
           }
+          if (srcObj.up) query.upmbps = srcObj.up;
+          if (srcObj.down) query.downmbps = srcObj.down;
+          if (srcObj.congestion) query.congestion = srcObj.congestion;
+          if (srcObj.finalMask) query.finalmask = "1";
           return generateURL({
             protocol: "hysteria2",
             username: srcObj.password,
@@ -1768,66 +1521,69 @@ export default {
       }
       return null;
     },
-    handleNetworkChange() {
-      this.v2ray.type = "none";
-      if (this.v2ray.tls === "none" && this.v2ray.net === "grpc") {
+    handleFileChange(e) {
+      const file = e.target.files[0];
+      let elem = document.querySelector("#QRCodeImport");
+      // eslint-disable-next-line no-self-assign
+      elem.outerHTML = elem.outerHTML;
+      this.$nextTick(() => {
+        document
+          .querySelector("#QRCodeImport")
+          .addEventListener("change", this.handleFileChange, false);
+      });
+      // console.log(file);
+      if (!file.type.match(/image\/.*/)) {
         this.$buefy.toast.open({
-          message: this.$t("setting.messages.grpcShouldWithTls"),
+          message: this.$t("import.qrcodeError"),
           type: "is-warning",
           position: "is-top",
           queue: false,
-          duration: 5000,
         });
-        this.$nextTick(() => {
-          this.v2ray.tls = "tls";
-        });
+        return;
       }
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        // target.result 该属性表示目标对象的DataURL
+        // console.log(e.target.result);
+        const file = e.target.result;
+        const qrcode = new Decoder();
+        qrcode
+          .scan(file)
+          .then((result) => {
+            console.log(result);
+            this.resolveURL(result.data);
+          })
+          .catch((error) => {
+            console.error(error);
+            this.$buefy.toast.open({
+              message: this.$t("import.qrcodeError"),
+              type: "is-warning",
+              position: "is-top",
+              queue: false,
+            });
+          });
+      };
+      reader.readAsDataURL(file);
     },
     async handleClickSubmit() {
       let valid = true;
       for (let k in this.$refs) {
-        if (!this.$refs.hasOwnProperty(k)) {
-          continue;
-        }
-        if (this.tabChoice === 0 && !k.startsWith("v2ray_")) {
-          continue;
-        }
-        if (this.tabChoice === 1 && !k.startsWith("wireguard_")) {
-          continue;
-        }
-        if (this.tabChoice === 2 && !k.startsWith("ss_")) {
-          continue;
-        }
-        if (this.tabChoice === 3 && !k.startsWith("ssr_")) {
-          continue;
-        }
-        if (this.tabChoice === 4 && !k.startsWith("trojan_")) {
-          continue;
-        }
-        if (this.tabChoice === 5 && !k.startsWith("juicity_")) {
-          continue;
-        }
-        if (this.tabChoice === 6 && !k.startsWith("tuic_")) {
-          continue;
-        }
-        if (this.tabChoice === 7 && !k.startsWith("hysteria2_")) {
-          continue;
-        }
-        if (this.tabChoice === 8 && !k.startsWith("http_")) {
-          continue;
-        }
-        if (this.tabChoice === 9 && !k.startsWith("socks5_")) {
-          continue;
-        }
-        if (this.tabChoice === 10 && !k.startsWith("anytls_")) {
-          continue;
-        }
+        if (!this.$refs.hasOwnProperty(k)) continue;
+        if (this.tabChoice === 0 && !k.startsWith("v2ray_")) continue;
+        if (this.tabChoice === 1 && !k.startsWith("wireguard_")) continue;
+        if (this.tabChoice === 2 && !k.startsWith("ss_")) continue;
+        if (this.tabChoice === 3 && !k.startsWith("ssr_")) continue;
+        if (this.tabChoice === 4 && !k.startsWith("trojan_")) continue;
+        if (this.tabChoice === 5 && !k.startsWith("juicity_")) continue;
+        if (this.tabChoice === 6 && !k.startsWith("tuic_")) continue;
+        if (this.tabChoice === 7 && !k.startsWith("hysteria2_")) continue;
+        if (this.tabChoice === 8 && !k.startsWith("http_")) continue;
+        if (this.tabChoice === 9 && !k.startsWith("socks5_")) continue;
+        if (this.tabChoice === 10 && !k.startsWith("anytls_")) continue;
         let x = this.$refs[k];
-        if (!x) {
-          continue;
-        }
         if (
-          x.$el.offsetParent && // is visible
+          x &&
+          x.$el.offsetParent &&
           x.hasOwnProperty("checkHtml5Validity") &&
           typeof x.checkHtml5Validity === "function" &&
           !x.checkHtml5Validity()
@@ -1840,13 +1596,10 @@ export default {
         return;
       }
       let coded = "";
-      // 0: v2ray, 1: wireguard, 2: ss, 3: ssr, 4: trojan, 5: juicity, 6: tuic, 7: hysteria2, 8: http, 9: socks5, 10: anytls
       if (this.tabChoice === 0) {
-        if (
-          this.v2ray.allowInsecure === true ||
-          this.v2ray.allowInsecure === "true"
-        ) {
-          let result = await new Promise((resolve) => {
+        const { allowInsecure, protocol } = this.v2ray;
+        if (allowInsecure) {
+          const result = await new Promise((resolve) => {
             this.$buefy.dialog.confirm({
               title: this.$t("InSecureConfirm.title"),
               message: this.$t("InSecureConfirm.message"),
@@ -1864,103 +1617,25 @@ export default {
         }
         coded = this.generateURL(this.v2ray);
       } else if (this.tabChoice === 1) {
-        // wireguard://address:port?key=value#name
         coded = this.generateURL(this.wireguard);
       } else if (this.tabChoice === 2) {
-        // ss://BASE64(method:password)@server:port?plugin=...&v2raya-backend=...#name
-        const { method, password, server, port, name, plugin, plugin_opts, backend } = this.ss;
-        let userinfo = btoa(`${method}:${password}`);
-        let params = [];
-        if (plugin) {
-          params.push(`plugin=${encodeURIComponent(plugin + (plugin_opts ? `;${plugin_opts}` : ""))}`);
-        }
-        if (backend) {
-          params.push(`v2raya-backend=${encodeURIComponent(backend)}`);
-        }
-        let url = `ss://${userinfo}@${server}:${port}`;
-        if (params.length) url += `?${params.join("&")}`;
-        if (name) url += `#${encodeURIComponent(name)}`;
-        coded = url;
+        coded = this.generateURL(this.ss);
       } else if (this.tabChoice === 3) {
-        // ssr://server:port:proto:method:obfs:base64(password)/?remarks=base64(remarks)
-        const { server, port, proto, method, obfs, password, name, protoParam, obfsParam } = this.ssr;
-        let pwdB64 = btoa(password);
-        let remarksB64 = name ? btoa(name) : "";
-        let protoParamB64 = protoParam ? btoa(protoParam) : "";
-        let obfsParamB64 = obfsParam ? btoa(obfsParam) : "";
-        let url = `ssr://${btoa(`${server}:${port}:${proto}:${method}:${obfs}:${pwdB64}/?remarks=${remarksB64}&protoparam=${protoParamB64}&obfsparam=${obfsParamB64}`)}`;
-        coded = url;
+        coded = this.generateURL(this.ssr);
       } else if (this.tabChoice === 4) {
-        // trojan://password@server:port?allowInsecure=1&sni=sni&v2raya-backend=...#name
-        const { password, server, port, allowInsecure, peer, name, backend } = this.trojan;
-        let params = [];
-        if (allowInsecure) params.push("allowInsecure=1");
-        if (peer) params.push(`sni=${encodeURIComponent(peer)}`);
-        if (backend) params.push(`v2raya-backend=${encodeURIComponent(backend)}`);
-        let url = `trojan://${encodeURIComponent(password)}@${server}:${port}`;
-        if (params.length) url += `?${params.join("&")}`;
-        if (name) url += `#${encodeURIComponent(name)}`;
-        coded = url;
+        coded = this.generateURL(this.trojan);
       } else if (this.tabChoice === 5) {
-        // juicity://uuid:password@server:port?allow_insecure=1&cc=xxx#name
-        const { uuid, password, server, port, allowInsecure, cc, sni, name } = this.juicity;
-        let params = [];
-        if (allowInsecure) params.push("allow_insecure=1");
-        if (cc) params.push(`congestion_control=${encodeURIComponent(cc)}`);
-        if (sni) params.push(`sni=${encodeURIComponent(sni)}`);
-        let url = `juicity://${uuid}:${password}@${server}:${port}`;
-        if (params.length) url += `?${params.join("&")}`;
-        if (name) url += `#${encodeURIComponent(name)}`;
-        coded = url;
+        coded = this.generateURL(this.juicity);
       } else if (this.tabChoice === 6) {
-        // tuic://uuid:password@server:port?allow_insecure=1&cc=xxx#name
-        const { uuid, password, server, port, allowInsecure, cc, sni, name } = this.tuic;
-        let params = [];
-        if (allowInsecure) params.push("allow_insecure=1");
-        if (cc) params.push(`congestion_control=${encodeURIComponent(cc)}`);
-        if (sni) params.push(`sni=${encodeURIComponent(sni)}`);
-        let url = `tuic://${uuid}:${password}@${server}:${port}`;
-        if (params.length) url += `?${params.join("&")}`;
-        if (name) url += `#${encodeURIComponent(name)}`;
-        coded = url;
+        coded = this.generateURL(this.tuic);
       } else if (this.tabChoice === 7) {
-        // hysteria2://password@server:port?insecure=1&obfs=xxx#name
-        const { password, server, port, allowInsecure, obfs, obfsPassword, sni, name } = this.hysteria2;
-        let params = [];
-        if (allowInsecure) params.push("insecure=1");
-        if (obfs) params.push(`obfs=${encodeURIComponent(obfs)}`);
-        if (obfsPassword) params.push(`obfs-password=${encodeURIComponent(obfsPassword)}`);
-        if (sni) params.push(`sni=${encodeURIComponent(sni)}`);
-        let url = `hysteria2://${encodeURIComponent(password)}@${server}:${port}`;
-        if (params.length) url += `?${params.join("&")}`;
-        if (name) url += `#${encodeURIComponent(name)}`;
-        coded = url;
+        coded = this.generateURL(this.hysteria2);
       } else if (this.tabChoice === 8) {
-        // http(s)://username:password@server:port#name
-        const { protocol, username, password, host, port, name } = this.http;
-        let url = `${protocol}://`;
-        if (username && password) url += `${encodeURIComponent(username)}:${encodeURIComponent(password)}@`;
-        url += `${host}:${port}`;
-        if (name) url += `#${encodeURIComponent(name)}`;
-        coded = url;
+        coded = this.generateURL(this.http);
       } else if (this.tabChoice === 9) {
-        // socks5://username:password@server:port#name
-        const { username, password, host, port, name } = this.socks5;
-        let url = `socks5://`;
-        if (username && password) url += `${encodeURIComponent(username)}:${encodeURIComponent(password)}@`;
-        url += `${host}:${port}`;
-        if (name) url += `#${encodeURIComponent(name)}`;
-        coded = url;
+        coded = this.generateURL(this.socks5);
       } else if (this.tabChoice === 10) {
-        // anytls://auth@host:port?peer=sni&insecure=1#name
-        const { auth, host, port, sni, allowInsecure, name } = this.anytls;
-        let params = [];
-        if (sni) params.push(`peer=${encodeURIComponent(sni)}`);
-        if (allowInsecure) params.push("insecure=1");
-        let url = `anytls://${encodeURIComponent(auth)}@${host}:${port}`;
-        if (params.length) url += `?${params.join("&")}`;
-        if (name) url += `#${encodeURIComponent(name)}`;
-        coded = url;
+        coded = this.generateURL(this.anytls);
       }
       this.$emit("submit", coded);
     },
@@ -1973,8 +1648,59 @@ export default {
   color: #4099ff !important;
 }
 
-.same-width-5 li {
-  min-width: 5em;
-  width: unset !important;
+.modal-card {
+  max-width: 720px;
+  width: 100%;
+}
+
+.b-tabs.is-vertical {
+  display: flex !important;
+  flex-direction: row !important;
+  align-items: stretch;
+
+  .tabs {
+    flex: 0 0 100px !important;
+    min-width: 100px !important;
+    max-width: 100px !important;
+
+    ul {
+      width: 100%;
+    }
+
+    li {
+      font-size: 0.85rem;
+
+      a {
+        padding: 0.5em 0.2em !important;
+        justify-content: flex-start;
+      }
+    }
+  }
+
+  .tab-content {
+    flex: 1 1 0 !important;
+    /* Allow to shrink to zero */
+    min-width: 0 !important;
+    padding: 0.5rem 0.2rem 0.5rem 0.5rem !important;
+    overflow-x: hidden;
+
+    .control,
+    .field,
+    input,
+    select {
+      max-width: 100% !important;
+      min-width: 0 !important;
+    }
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .b-tabs.is-vertical {
+    .tabs {
+      flex: 0 0 80px !important;
+      min-width: 80px !important;
+      max-width: 80px !important;
+    }
+  }
 }
 </style>

--- a/gui/src/components/modalSetting.vue
+++ b/gui/src/components/modalSetting.vue
@@ -410,6 +410,8 @@ export default {
     tunTeardownScript: "",
     tunProcessBackend: "",
     tunExcludeProcesses: "",
+    ssBackend: "",
+    trojanBackend: "",
     pacAutoUpdateMode: "none",
     pacAutoUpdateIntervalHour: 0,
     subscriptionAutoUpdateMode: "none",
@@ -540,6 +542,8 @@ export default {
             tunTeardownScript: this.tunTeardownScript,
             tunProcessBackend: this.tunProcessBackend,
             tunExcludeProcesses: this.tunExcludeProcesses,
+            ssBackend: this.ssBackend,
+            trojanBackend: this.trojanBackend,
             encryption: this.encryption,
           },
           cancelToken: new axios.CancelToken(function executor(c) {

--- a/gui/src/components/modalSetting.vue
+++ b/gui/src/components/modalSetting.vue
@@ -244,6 +244,13 @@
 
       <b-field label-position="on-border">
         <template slot="label">
+          Encryption
+        </template>
+        <b-input v-model="encryption" expanded placeholder="none" />
+      </b-field>
+
+      <b-field label-position="on-border">
+        <template slot="label">
           {{ $t("setting.logLevel") }}
         </template>
         <b-select v-model="logLevel" expanded>
@@ -297,7 +304,6 @@
           custom-class="no-shadow" type="number" min="1" max="1024" validation-icon=" iconfont icon-alert"
           style="flex: 1" />
       </b-field>
-
 
       <b-field v-show="pacMode === 'gfwlist' || transparent === 'gfwlist'" :label="$t('setting.autoUpdateGfwlist')"
         label-position="on-border">
@@ -397,9 +403,6 @@ export default {
     routeOnly: false,
     tproxyExcludedInterfaces: "",
     tunAutoRoute: true,
-    tunBypassInterfaces: "",
-    tunBypassInterfacesList: [],
-    tunBypassCustom: "",
     availableInterfaces: [],
     tunRouteShellType: "",
     tunRouteShellPath: "",
@@ -412,6 +415,7 @@ export default {
     subscriptionAutoUpdateMode: "none",
     subscriptionAutoUpdateIntervalHour: 0,
     inboundSniffing: "no",
+    encryption: "",
     customSiteDAT: {},
     pacMode: "whitelist",
     showClockPicker: true,
@@ -423,31 +427,6 @@ export default {
     tinytunSupported: false,
   }),
   computed: {
-    tunBypassInterfacesComputed: {
-      get() {
-        const parts = [];
-        if (this.tunBypassInterfacesList.length > 0) {
-          parts.push(...this.tunBypassInterfacesList);
-        }
-        if (this.tunBypassCustom.trim()) {
-          parts.push(
-            ...this.tunBypassCustom
-              .split(',')
-              .map((s) => s.trim())
-              .filter((s) => s.length > 0)
-          );
-        }
-        return [...new Set(parts)].join(',');
-      },
-      set(val) {
-        const parts = val
-          ? val.split(',').map((s) => s.trim()).filter((s) => s.length > 0)
-          : [];
-        const known = (this.availableInterfaces || []).map((i) => i.name);
-        this.tunBypassInterfacesList = parts.filter((p) => known.includes(p));
-        this.tunBypassCustom = parts.filter((p) => !known.includes(p)).join(',');
-      },
-    },
     lite() {
       return window.localStorage["lite"] && parseInt(window.localStorage["lite"]) > 0;
     },
@@ -462,18 +441,29 @@ export default {
       }
       return toInt(port);
     },
+    tunBypassInterfacesList: {
+      get() {
+        return this.availableInterfaces
+          .filter((i) => i.isBypassed)
+          .map((i) => i.name);
+      },
+      set(val) {
+        this.availableInterfaces.forEach((i) => {
+          i.isBypassed = val.includes(i.name);
+        });
+      },
+    },
+    tunBypassInterfacesComputed() {
+      let ifaces = this.availableInterfaces
+        .filter((i) => i.isBypassed)
+        .map((i) => i.name);
+      if (this.tunBypassCustom) {
+        ifaces.push(...this.tunBypassCustom.split(",").map((s) => s.trim()));
+      }
+      return ifaces.join(",");
+    },
   },
   watch: {
-    transparentType(val) {
-      if (val === 'tun' && this.tinytunSupported) {
-        this.fetchNetworkInterfaces();
-      }
-    },
-    tinytunSupported(val) {
-      if (val && this.transparentType === 'tun') {
-        this.fetchNetworkInterfaces();
-      }
-    },
   },
   created() {
     this.getSettingData();
@@ -481,17 +471,6 @@ export default {
   methods: {
     dayjs() {
       return dayjs.apply(this, arguments);
-    },
-    fetchNetworkInterfaces() {
-      this.$axios({ url: apiRoot + '/networkInterfaces' }).then((res) => {
-        if (res.data && res.data.data && res.data.data.interfaces) {
-          this.availableInterfaces = res.data.data.interfaces;
-          // Re-apply the tunBypassInterfaces string now that we know available names
-          if (this.tunBypassInterfaces) {
-            this.tunBypassInterfacesComputed = this.tunBypassInterfaces;
-          }
-        }
-      });
     },
     getSettingData() {
       this.$axios({
@@ -518,9 +497,6 @@ export default {
               this.os = versionRes.data.data.os || "";
               this.isRoot = versionRes.data.data.isRoot || false;
               this.tinytunSupported = versionRes.data.data.tinytunSupported || false;
-            }
-            if (this.transparentType === 'tun' && this.tinytunSupported) {
-              this.fetchNetworkInterfaces();
             }
           });
           if (this.lite) {
@@ -564,6 +540,7 @@ export default {
             tunTeardownScript: this.tunTeardownScript,
             tunProcessBackend: this.tunProcessBackend,
             tunExcludeProcesses: this.tunExcludeProcesses,
+            encryption: this.encryption,
           },
           cancelToken: new axios.CancelToken(function executor(c) {
             cancel = c;

--- a/gui/src/components/modalSharing.vue
+++ b/gui/src/components/modalSharing.vue
@@ -7,7 +7,7 @@
       <div><canvas id="canvas" class="qrcode"></canvas></div>
       <div class="tags has-addons is-centered" style="position: relative">
         <span
-          class="tag is-rounded is-dark sharingAddressTag"
+          class="tag is-rounded is-dark sharingAddressTagModal"
           style="position: relative"
           :data-clipboard-text="sharingAddress"
         >
@@ -18,7 +18,7 @@
         </span>
         <div id="tag-cover-text">{{ $t("operations.copyLink") }}</div>
         <span
-          class="tag is-rounded is-primary sharingAddressTag"
+          class="tag is-rounded is-primary sharingAddressTagModal"
           style="position: relative"
           :data-clipboard-text="sharingAddress"
         >
@@ -91,7 +91,7 @@ export default {
     document
       .querySelector("#QRCodeImport")
       .addEventListener("change", this.handleFileChange, false);
-    this.clipboard = new ClipboardJS(".sharingAddressTag");
+    this.clipboard = new ClipboardJS(".sharingAddressTagModal");
     this.clipboard.on("success", (e) => {
       this.$buefy.toast.open({
         message: this.$t("common.success"),
@@ -124,7 +124,7 @@ export default {
         // console.log("QRCode has been generated successfully!");
       }
     );
-    let targets = document.querySelectorAll(".sharingAddressTag");
+    let targets = document.querySelectorAll(".sharingAddressTagModal");
     let covers = document.querySelectorAll(".tag-cover");
     let coverText = document.querySelector("#tag-cover-text");
     let enter = () => {

--- a/gui/src/locales/en.js
+++ b/gui/src/locales/en.js
@@ -50,6 +50,8 @@ export default {
         "According to the docs of {name}, if you use {name}, AllowInsecure will be forbidden.",
       notRecommend:
         "According to the docs of {name}, if you use {name}, AllowInsecure is not recommend.",
+      hysteria2FinalMaskInfo:
+        "When enabled, v2rayA will use native Xray Hysteria2 outbound with FinalMask support. This requires Xray-core v26.1.23 or later (v26.2.6+ recommended). Otherwise, v2rayA will use bridge architecture for compatibility.",
     },
   },
   InSecureConfirm: {

--- a/gui/src/node.vue
+++ b/gui/src/node.vue
@@ -622,8 +622,10 @@
       trap-focus
       aria-role="dialog"
       aria-modal
+      destroy-on-hide
     >
       <ModalServer
+        v-if="showModalServer"
         :which="which"
         :readonly="modalServerReadOnly"
         @submit="handleModalServerSubmit"
@@ -907,30 +909,12 @@ export default {
     });
   },
   beforeDestroy() {
-    this.clipboard.destroy();
+    if (this.clipboard) this.clipboard.destroy();
   },
   mounted() {
     document
       .querySelector("#QRCodeImport")
       .addEventListener("change", this.handleFileChange, false);
-    this.clipboard = new ClipboardJS(".sharingAddressTag");
-    this.clipboard.on("success", (e) => {
-      this.$buefy.toast.open({
-        message: this.$t("common.success"),
-        type: "is-primary",
-        position: "is-top",
-        queue: false,
-      });
-      e.clearSelection();
-    });
-    this.clipboard.on("error", (e) => {
-      this.$buefy.toast.open({
-        message: this.$t("common.fail") + ", error:" + e.toLocaleString(),
-        type: "is-warning",
-        position: "is-top",
-        queue: false,
-      });
-    });
     const that = this;
     let scrollTimer = null;
     window.addEventListener("scroll", (e) => {

--- a/service/core/coreObj/coreObj.go
+++ b/service/core/coreObj/coreObj.go
@@ -120,8 +120,13 @@ type Server struct {
 	Method   string         `json:"method,omitempty"`
 	Ota      bool           `json:"ota,omitempty"`
 	Password string         `json:"password,omitempty"`
+	Auth     string         `json:"auth,omitempty"`
 	Port     int            `json:"port,omitempty"`
 	Users    []OutboundUser `json:"users,omitempty"`
+}
+type UDPHop struct {
+	Ports    string `json:"ports,omitempty"`
+	Interval string `json:"interval,omitempty"`
 }
 type Settings struct {
 	Vnext          interface{} `json:"vnext,omitempty"`
@@ -132,6 +137,7 @@ type Settings struct {
 	Network        string      `json:"network,omitempty"`
 	Redirect       string      `json:"redirect,omitempty"`
 	UserLevel      *int        `json:"userLevel,omitempty"`
+	Version        int         `json:"version,omitempty"`
 	// Inlined, when non-nil, replaces the entire settings JSON during serialization.
 	// Used for non-standard protocols such as anytls/juicity whose settings do not
 	// fit the standard fields above.
@@ -169,6 +175,28 @@ type WsSettings struct {
 	MaxEarlyData        int     `json:"maxEarlyData,omitempty"`
 	EarlyDataHeaderName string  `json:"earlyDataHeaderName,omitempty"`
 }
+type HysteriaSettings struct {
+	Version int    `json:"version,omitempty"`
+	Auth    string `json:"auth,omitempty"`
+}
+type MaskItem struct {
+	Type     string      `json:"type"`
+	Settings interface{} `json:"settings,omitempty"`
+}
+type QuicParams struct {
+	Up                      string  `json:"up,omitempty"`
+	Down                    string  `json:"down,omitempty"`
+	HopInterval             string  `json:"hopInterval,omitempty"`
+	InitStreamReceiveWindow int     `json:"initStreamReceiveWindow,omitempty"`
+	InitConnReceiveWindow   int     `json:"initConnReceiveWindow,omitempty"`
+	Congestion              string  `json:"congestion,omitempty"`
+	UDPHop                  *UDPHop `json:"udpHop,omitempty"`
+}
+type FinalMask struct {
+	TCP        []MaskItem  `json:"tcp,omitempty"`
+	UDP        []MaskItem  `json:"udp,omitempty"`
+	QuicParams *QuicParams `json:"quicParams,omitempty"`
+}
 type StreamSettings struct {
 	Network         string           `json:"network,omitempty"`
 	Security        string           `json:"security,omitempty"`
@@ -181,8 +209,10 @@ type StreamSettings struct {
 	WsSettings      *WsSettings      `json:"wsSettings,omitempty"`
 	HTTPSettings    *HttpSettings    `json:"httpSettings,omitempty"`
 	GrpcSettings    *GrpcSettings    `json:"grpcSettings,omitempty"`
-	QuicSettings    *QuicSettings    `json:"quicSettings,omitempty"`
-	Sockopt         *Sockopt         `json:"sockopt,omitempty"`
+	QuicSettings     *QuicSettings     `json:"quicSettings,omitempty"`
+	HysteriaSettings *HysteriaSettings `json:"hysteriaSettings,omitempty"`
+	FinalMask        *FinalMask        `json:"finalmask,omitempty"`
+	Sockopt          *Sockopt          `json:"sockopt,omitempty"`
 }
 type RealitySettings struct {
 	ServerName  string `json:"serverName,omitempty"`
@@ -337,6 +367,8 @@ type Policy struct {
 			DownlinkOnly      int  `json:"downlinkOnly,omitempty"`
 			StatsUserUplink   bool `json:"statsUserUplink,omitempty"`
 			StatsUserDownlink bool `json:"statsUserDownlink,omitempty"`
+			StatusUserUplink   bool `json:"statusUserUplink,omitempty"`
+			StatusUserDownlink bool `json:"statusUserDownlink,omitempty"`
 			BufferSize        int  `json:"bufferSize,omitempty"`
 		} `json:"0"`
 	} `json:"levels"`

--- a/service/core/serverObj/anytls.go
+++ b/service/core/serverObj/anytls.go
@@ -3,6 +3,7 @@ package serverObj
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"strconv"
 
@@ -12,14 +13,14 @@ import (
 func init() {
 	FromLinkRegister("anytls", NewAnyTLS)
 	EmptyRegister("anytls", func() (ServerObj, error) {
-		return new(AnyTLS), nil
+		return &AnyTLS{Protocol: "anytls"}, nil
 	})
 }
 
 type AnyTLS struct {
-	Name     string `json:"name"`
-	Server   string `json:"server"`
+	Address  string `json:"address" server:"server" hostname:"hostname" add:"add"`
 	Port     int    `json:"port"`
+	Name     string `json:"name"`
 	Protocol string `json:"protocol"`
 	Link     string `json:"link"`
 }
@@ -28,21 +29,23 @@ func NewAnyTLS(link string) (ServerObj, error) {
 	return ParseAnyTLSURL(link)
 }
 
-func ParseAnyTLSURL(link string) (data *AnyTLS, err error) {
+func ParseAnyTLSURL(link string) (*AnyTLS, error) {
 	u, err := url.Parse(link)
 	if err != nil {
 		return nil, err
 	}
-	port, err := strconv.Atoi(u.Port())
+	host, portStr, err := net.SplitHostPort(u.Host)
 	if err != nil {
-		return nil, err
+		host = u.Host
+		portStr = "443"
 	}
+	port, _ := strconv.Atoi(portStr)
 	return &AnyTLS{
-		Name:     u.Fragment,
-		Server:   u.Hostname(),
+		Address:  host,
 		Port:     port,
-		Protocol: "anytls",
+		Name:     u.Fragment,
 		Link:     link,
+		Protocol: "anytls",
 	}, nil
 }
 
@@ -68,11 +71,11 @@ func (s *AnyTLS) Configuration(info PriorInfo) (c Configuration, err error) {
 	}
 	q := u.Query()
 	sni := q.Get("sni")
-	insecure := q.Get("insecure") == "1" || q.Get("allowInsecure") == "1"
+	insecure := q.Get("insecure") == "1" || q.Get("allowInsecure") == "true" || q.Get("allowInsecure") == "1"
 	minIdle, _ := strconv.Atoi(q.Get("minIdleSession"))
 
 	settingsJSON, err := json.Marshal(anytlsSettings{
-		Address:         s.Server,
+		Address:         s.Address,
 		Port:            s.Port,
 		Password:        password,
 		SNI:             sni,
@@ -102,15 +105,15 @@ func (s *AnyTLS) NeedPluginPort() bool {
 }
 
 func (s *AnyTLS) ProtoToShow() string {
-	return fmt.Sprintf("anytls")
+	return "anytls"
 }
 
 func (s *AnyTLS) GetProtocol() string {
-	return s.Protocol
+	return "anytls"
 }
 
 func (s *AnyTLS) GetHostname() string {
-	return s.Server
+	return s.Address
 }
 
 func (s *AnyTLS) GetPort() int {

--- a/service/core/serverObj/http.go
+++ b/service/core/serverObj/http.go
@@ -13,68 +13,28 @@ func init() {
 	FromLinkRegister("http-proxy", NewHTTP)
 	FromLinkRegister("https-proxy", NewHTTP)
 	EmptyRegister("http", func() (ServerObj, error) {
-		return new(HTTP), nil
+		return &HTTP{Protocol: "http"}, nil
 	})
 	EmptyRegister("https", func() (ServerObj, error) {
-		return new(HTTP), nil
-	})
-	EmptyRegister("http-proxy", func() (ServerObj, error) {
-		return new(HTTP), nil
-	})
-	EmptyRegister("https-proxy", func() (ServerObj, error) {
-		return new(HTTP), nil
+		return &HTTP{Protocol: "https"}, nil
 	})
 }
 
 type HTTP struct {
-	Name     string `json:"name"`
-	Server   string `json:"server"`
+	Address  string `json:"address" server:"server" hostname:"hostname" add:"add" host:"host"`
 	Port     int    `json:"port"`
 	Username string `json:"username"`
 	Password string `json:"password"`
+	Name     string `json:"name"`
 	Protocol string `json:"protocol"`
+	Link     string `json:"link"`
 }
 
 func NewHTTP(link string) (ServerObj, error) {
 	return ParseHttpURL(link)
 }
 
-func ParseHttpURL(u string) (data *HTTP, err error) {
-	t, err := url.Parse(u)
-	if err != nil {
-		return nil, ErrInvalidParameter
-	}
-	port, err := strconv.Atoi(t.Port())
-	if err != nil {
-		return nil, ErrInvalidParameter
-	}
-	data = &HTTP{
-		Name:   t.Fragment,
-		Server: t.Hostname(),
-		Port:   port,
-	}
-	if t.User != nil && len(t.User.String()) > 0 {
-		data.Username = t.User.Username()
-		data.Password, _ = t.User.Password()
-	}
-	switch t.Scheme {
-	case "https-proxy", "https":
-		data.Protocol = "https"
-		if data.Port == 0 {
-			data.Port = 443
-		}
-	case "http-proxy", "http":
-		data.Protocol = "http"
-		if data.Port == 0 {
-			data.Port = 80
-		}
-	default:
-		data.Protocol = t.Scheme
-	}
-	return data, nil
-}
-
-func (h *HTTP) Configuration(info PriorInfo) (c Configuration, err error) {
+func (h *HTTP) Configuration(info PriorInfo) (Configuration, error) {
 	socks5 := url.URL{
 		Scheme: "socks5",
 		Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(info.PluginPort)),
@@ -88,17 +48,7 @@ func (h *HTTP) Configuration(info PriorInfo) (c Configuration, err error) {
 }
 
 func (h *HTTP) ExportToURL() string {
-	var user *url.Userinfo
-	if h.Username != "" && h.Password != "" {
-		user = url.UserPassword(h.Username, h.Password)
-	}
-	u := &url.URL{
-		Scheme:   h.Protocol,
-		User:     user,
-		Host:     net.JoinHostPort(h.Server, strconv.Itoa(h.Port)),
-		Fragment: h.Name,
-	}
-	return u.String()
+	return h.Link
 }
 
 func (h *HTTP) NeedPluginPort() bool {
@@ -106,7 +56,7 @@ func (h *HTTP) NeedPluginPort() bool {
 }
 
 func (h *HTTP) ProtoToShow() string {
-	return h.Protocol
+	return strings.ToUpper(h.Protocol)
 }
 
 func (h *HTTP) GetProtocol() string {
@@ -114,7 +64,7 @@ func (h *HTTP) GetProtocol() string {
 }
 
 func (h *HTTP) GetHostname() string {
-	return h.Server
+	return h.Address
 }
 
 func (h *HTTP) GetPort() int {
@@ -127,4 +77,35 @@ func (h *HTTP) GetName() string {
 
 func (h *HTTP) SetName(name string) {
 	h.Name = name
+}
+
+func ParseHttpURL(link string) (*HTTP, error) {
+	u, err := url.Parse(link)
+	if err != nil {
+		return nil, err
+	}
+	host, portStr, _ := net.SplitHostPort(u.Host)
+	if portStr == "" {
+		if u.Scheme == "https" || u.Scheme == "https-proxy" {
+			portStr = "443"
+		} else {
+			portStr = "80"
+		}
+	}
+	port, _ := strconv.Atoi(portStr)
+	h := &HTTP{
+		Address:  host,
+		Port:     port,
+		Name:     u.Fragment,
+		Link:     link,
+		Protocol: "http",
+	}
+	if u.Scheme == "https" || u.Scheme == "https-proxy" {
+		h.Protocol = "https"
+	}
+	if u.User != nil {
+		h.Username = u.User.Username()
+		h.Password, _ = u.User.Password()
+	}
+	return h, nil
 }

--- a/service/core/serverObj/hysteria2.go
+++ b/service/core/serverObj/hysteria2.go
@@ -5,7 +5,8 @@ import (
 	"net"
 	"net/url"
 	"strconv"
-	"strings"
+
+	"github.com/v2rayA/v2rayA/core/coreObj"
 )
 
 func init() {
@@ -20,11 +21,16 @@ func init() {
 }
 
 type Hysteria2 struct {
-	Name     string `json:"name"`
-	Server   string `json:"server"`
-	Port     int    `json:"port"`
-	Protocol string `json:"protocol"`
-	Link     string `json:"link"`
+	Name          string `json:"name"`
+	Server        string `json:"server"`
+	Port          int    `json:"port"`
+	Auth          string `json:"auth"`
+	Obfs          string `json:"obfs"`
+	ObfsPassword  string `json:"obfsPassword"`
+	SNI           string `json:"sni"`
+	AllowInsecure bool   `json:"allowInsecure"`
+	Protocol      string `json:"protocol"`
+	Link          string `json:"link"`
 }
 
 func NewHysteria2(link string) (ServerObj, error) {
@@ -44,24 +50,62 @@ func ParseHysteria2URL(link string) (data *Hysteria2, err error) {
 	if err != nil {
 		return nil, err
 	}
+	auth := u.User.Username()
+	if p, ok := u.User.Password(); ok {
+		auth += ":" + p
+	}
+	q := u.Query()
 	return &Hysteria2{
-		Name:     u.Fragment,
-		Server:   u.Hostname(),
-		Port:     port,
-		Protocol: "hysteria2",
-		Link:     link,
+		Name:          u.Fragment,
+		Server:        u.Hostname(),
+		Port:          port,
+		Auth:          auth,
+		Obfs:          q.Get("obfs"),
+		ObfsPassword:  q.Get("obfs-password"),
+		SNI:           q.Get("sni"),
+		AllowInsecure: q.Get("insecure") == "1" || q.Get("allowInsecure") == "true",
+		Protocol:      "hysteria2",
+		Link:          link,
 	}, nil
 }
 
 func (s *Hysteria2) Configuration(info PriorInfo) (c Configuration, err error) {
-	socks5 := url.URL{
-		Scheme: "socks5",
-		Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(info.PluginPort)),
+	core := coreObj.OutboundObject{
+		Tag:      info.Tag,
+		Protocol: "hysteria",
 	}
-	chain := []string{socks5.String(), s.Link}
+	core.Settings.Version = 2
+	core.Settings.Address = s.Server
+	core.Settings.Port = s.Port
+
+	core.StreamSettings = &coreObj.StreamSettings{
+		Network:  "hysteria",
+		Security: "tls",
+		TLSSettings: &coreObj.TLSSettings{
+			ServerName:    s.SNI,
+			AllowInsecure: s.AllowInsecure,
+			Alpn:          []string{"h3"},
+		},
+		HysteriaSettings: &coreObj.HysteriaSettings{
+			Version: 2,
+			Auth:    s.Auth,
+		},
+	}
+	if s.Obfs == "salamander" {
+		core.StreamSettings.FinalMask = &coreObj.FinalMask{
+			UDP: []coreObj.MaskItem{
+				{
+					Type: "salamander",
+					Settings: map[string]string{
+						"password": s.ObfsPassword,
+					},
+				},
+			},
+		}
+	}
 	return Configuration{
-		CoreOutbound: info.PluginObj(),
-		PluginChain:  strings.Join(chain, ","),
+		CoreOutbound: core,
+		PluginChain:  "",
 		UDPSupport:   true,
 	}, nil
 }
@@ -71,7 +115,7 @@ func (s *Hysteria2) ExportToURL() string {
 }
 
 func (s *Hysteria2) NeedPluginPort() bool {
-	return true
+	return false
 }
 
 func (s *Hysteria2) ProtoToShow() string {

--- a/service/core/serverObj/hysteria2.go
+++ b/service/core/serverObj/hysteria2.go
@@ -41,7 +41,6 @@ func (h *Hysteria2) ExportToURL() string {
 	return h.Link
 }
 
-<<<<<<< HEAD
 func (h *Hysteria2) ProtoToShow() string {
 	return "Hysteria2"
 }
@@ -67,9 +66,6 @@ func (h *Hysteria2) SetName(name string) {
 }
 
 func (h *Hysteria2) Configuration(info PriorInfo) (Configuration, error) {
-=======
-func (h *Hysteria2) Configuration(reg coreObj.OutboundRegistry) (coreObj.OutboundObject, error) {
->>>>>>> b9b00afb (fix(gui): improve mobile responsiveness for vertical tabs and refine SS URL parsing)
 	// Re-parse the link to get the latest credentials and params
 	parsed, err := ParseHysteria2URL(h.Link)
 	if err == nil {
@@ -85,12 +81,8 @@ func (h *Hysteria2) Configuration(reg coreObj.OutboundRegistry) (coreObj.Outboun
 		h.Port = parsed.Port
 	}
 	
-<<<<<<< HEAD
 	coreOutbound := coreObj.OutboundObject{
 		Tag:      info.Tag,
-=======
-	out := coreObj.OutboundObject{
->>>>>>> b9b00afb (fix(gui): improve mobile responsiveness for vertical tabs and refine SS URL parsing)
 		Protocol: "hysteria2",
 		Settings: coreObj.Settings{
 			Address: h.Address,

--- a/service/core/serverObj/hysteria2.go
+++ b/service/core/serverObj/hysteria2.go
@@ -1,21 +1,17 @@
 package serverObj
 
 import (
-	"fmt"
-	"github.com/v2rayA/v2rayA/core/coreObj"
 	"net"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/v2rayA/v2rayA/core/coreObj"
 )
 
 func init() {
-	FromLinkRegister("hysteria2", func(link string) (ServerObj, error) {
-		return ParseHysteria2URL(link)
-	})
-	FromLinkRegister("hy2", func(link string) (ServerObj, error) {
-		return ParseHysteria2URL(link)
-	})
+	FromLinkRegister("hysteria2", NewHysteria2)
+	FromLinkRegister("hy2", NewHysteria2)
 	EmptyRegister("hysteria2", func() (ServerObj, error) {
 		return new(Hysteria2), nil
 	})
@@ -25,153 +21,156 @@ func init() {
 }
 
 type Hysteria2 struct {
-	coreObj.ServerCommon
-	Password      string `json:"password"`
-	Insecure      bool   `json:"insecure"`
-	Sni           string `json:"sni"`
-	Obfs          string `json:"obfs"`
-	ObfsPassword  string `json:"obfs-password"`
-	UpMbps        string `json:"upmbps"`
-	DownMbps      string `json:"downmbps"`
+	Address      string `json:"address" server:"server" hostname:"hostname" add:"add"`
+	Port         int    `json:"port"`
+	Auth         string `json:"auth"`
+	Obfs         string `json:"obfs"`
+	ObfsPassword string `json:"obfsPassword"`
+	Sni          string `json:"sni"`
+	Up           string `json:"up"`
+	Down         string `json:"down"`
 	Congestion    string `json:"congestion"`
-	Link          string `json:"link"`
+	Insecure     bool   `json:"insecure"`
+	FinalMask    bool   `json:"finalMask"`
+	Name         string `json:"name"`
+	Protocol     string `json:"protocol"`
+	Link         string `json:"link"`
 }
 
-func (h *Hysteria2) ExportToURL() string {
-	return h.Link
+func NewHysteria2(link string) (ServerObj, error) {
+	return ParseHysteria2URL(link)
 }
 
-func (h *Hysteria2) ProtoToShow() string {
-	return "Hysteria2"
-}
-
-func (h *Hysteria2) GetProtocol() string {
-	return "hysteria2"
-}
-
-func (h *Hysteria2) GetHostname() string {
-	return h.Hostname
-}
-
-func (h *Hysteria2) GetPort() int {
-	return h.Port
-}
-
-func (h *Hysteria2) GetName() string {
-	return h.Hostname
-}
-
-func (h *Hysteria2) SetName(name string) {
-	h.Hostname = name
-}
-
-func (h *Hysteria2) Configuration(info PriorInfo) (Configuration, error) {
-	// Re-parse the link to get the latest credentials and params
-	parsed, err := ParseHysteria2URL(h.Link)
-	if err == nil {
-		h.Password = parsed.Password
-		h.Insecure = parsed.Insecure
-		h.Sni = parsed.Sni
-		h.Obfs = parsed.Obfs
-		h.ObfsPassword = parsed.ObfsPassword
-		h.UpMbps = parsed.UpMbps
-		h.DownMbps = parsed.DownMbps
-		h.Congestion = parsed.Congestion
-		h.Address = parsed.Address
-		h.Port = parsed.Port
-	}
-	
-	coreOutbound := coreObj.OutboundObject{
-		Tag:      info.Tag,
-		Protocol: "hysteria2",
-		Settings: coreObj.Settings{
-			Address: h.Address,
-			Port:    h.Port,
-		},
-		StreamSettings: &coreObj.StreamSettings{
-			Network: "udp",
-			HysteriaSettings: &coreObj.HysteriaSettings{
-				Auth: h.Password,
-			},
-			Security: "tls",
-			TLSSettings: &coreObj.TLSSettings{
-				ServerName: h.Sni,
-				AllowInsecure: h.Insecure,
-			},
-			Sockopt: &coreObj.Sockopt{
-				Mark: func() *int { i := 128; return &i }(),
-			},
-		},
-	}
-	
-	if h.Obfs != "" && h.Obfs != "none" {
-		coreOutbound.StreamSettings.HysteriaSettings.Obfs = &coreObj.MaskItem{
-			Type:     h.Obfs,
-			Password: h.ObfsPassword,
-		}
-	}
-	
-	if h.UpMbps != "" || h.DownMbps != "" {
-		up, _ := strconv.Atoi(strings.TrimSuffix(strings.ToLower(h.UpMbps), " mbps"))
-		down, _ := strconv.Atoi(strings.TrimSuffix(strings.ToLower(h.DownMbps), " mbps"))
-		if coreOutbound.StreamSettings.HysteriaSettings.QuicParams == nil {
-			coreOutbound.StreamSettings.HysteriaSettings.QuicParams = &coreObj.QuicParams{}
-		}
-		coreOutbound.StreamSettings.HysteriaSettings.QuicParams.Up = up
-		coreOutbound.StreamSettings.HysteriaSettings.QuicParams.Down = down
-	}
-	
-	if h.Congestion != "" {
-		if coreOutbound.StreamSettings.HysteriaSettings.QuicParams == nil {
-			coreOutbound.StreamSettings.HysteriaSettings.QuicParams = &coreObj.QuicParams{}
-		}
-		coreOutbound.StreamSettings.HysteriaSettings.QuicParams.Congestion = h.Congestion
-	}
-	
-	return Configuration{
-		CoreOutbound: coreOutbound,
-		UDPSupport:   true,
-	}, nil
-}
-
-func (h *Hysteria2) NeedPluginPort() bool {
-	return false
-}
-
-func (h *Hysteria2) GetLink() string {
-	return h.Link
-}
-
-func ParseHysteria2URL(link string) (*Hysteria2, error) {
+func ParseHysteria2URL(link string) (data *Hysteria2, err error) {
 	u, err := url.Parse(link)
 	if err != nil {
 		return nil, err
 	}
-	if u.Scheme != "hysteria2" && u.Scheme != "hy2" {
-		return nil, fmt.Errorf("invalid scheme")
+	host, portStr, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		host = u.Host
+		portStr = "443"
 	}
-	host, portStr, _ := net.SplitHostPort(u.Host)
 	port, _ := strconv.Atoi(portStr)
-	h := &Hysteria2{
-		ServerCommon: coreObj.ServerCommon{
-			Address: host,
-			Port:    port,
-		},
-		Password:     u.User.Username(),
-		Insecure:     u.Query().Get("insecure") == "1",
-		Sni:          u.Query().Get("sni"),
-		Obfs:         u.Query().Get("obfs"),
-		ObfsPassword: u.Query().Get("obfs-password"),
-		UpMbps:       u.Query().Get("upmbps"),
-		DownMbps:     u.Query().Get("downmbps"),
-		Congestion:   u.Query().Get("congestion"),
-		Link:         link,
+	auth := u.User.Username()
+	if p, ok := u.User.Password(); ok {
+		auth += ":" + p
 	}
-	if h.Password == "" && u.User != nil {
-		if p, ok := u.User.Password(); ok {
-			h.Password = p
+	q := u.Query()
+	return &Hysteria2{
+		Name:          u.Fragment,
+		Address:       host,
+		Port:          port,
+		Auth:          auth,
+		Obfs:          q.Get("obfs"),
+		ObfsPassword:  q.Get("obfs-password"),
+		Sni:           q.Get("sni"),
+		Up:            q.Get("upmbps"),
+		Down:          q.Get("downmbps"),
+		Congestion:    q.Get("congestion"),
+		Insecure:      q.Get("insecure") == "1" || q.Get("allowInsecure") == "true",
+		FinalMask:     q.Get("finalmask") == "1",
+		Protocol:      "hysteria2",
+		Link:          link,
+	}, nil
+}
+
+func (s *Hysteria2) Configuration(info PriorInfo) (c Configuration, err error) {
+	if !s.FinalMask {
+		// Bridge mode for backward compatibility
+		socks5 := url.URL{
+			Scheme: "socks5",
+			Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(info.PluginPort)),
+		}
+		chain := []string{socks5.String(), s.Link}
+		return Configuration{
+			CoreOutbound: info.PluginObj(),
+			PluginChain:  strings.Join(chain, ","),
+			UDPSupport:   true,
+		}, nil
+	}
+
+	// Native Hysteria2 mode for latest Xray
+	core := coreObj.OutboundObject{
+		Tag:      info.Tag,
+		Protocol: "hysteria",
+	}
+	core.Settings.Version = 2
+	core.Settings.Address = s.Address
+	core.Settings.Port = s.Port
+
+	core.StreamSettings = &coreObj.StreamSettings{
+		Network:  "hysteria",
+		Security: "tls",
+		TLSSettings: &coreObj.TLSSettings{
+			ServerName:    s.Sni,
+			AllowInsecure: s.Insecure,
+			Alpn:          []string{"h3"},
+		},
+		HysteriaSettings: &coreObj.HysteriaSettings{
+			Version: 2,
+			Auth:    s.Auth,
+		},
+	}
+	if s.Obfs == "salamander" || s.Up != "" || s.Down != "" || s.Congestion != "" {
+		core.StreamSettings.FinalMask = &coreObj.FinalMask{
+			QuicParams: &coreObj.QuicParams{
+				Up:         s.Up,
+				Down:       s.Down,
+				Congestion: s.Congestion,
+			},
+		}
+		if s.Obfs == "salamander" {
+			core.StreamSettings.FinalMask.UDP = []coreObj.MaskItem{
+				{
+					Type: "salamander",
+					Settings: map[string]string{
+						"password": s.ObfsPassword,
+					},
+				},
+			}
 		}
 	}
-	h.Hostname = u.Fragment
-	return h, nil
+	return Configuration{
+		CoreOutbound: core,
+		PluginChain:  "",
+		UDPSupport:   true,
+	}, nil
+}
+
+func (s *Hysteria2) ExportToURL() string {
+	u, err := url.Parse(s.Link)
+	if err != nil {
+		return s.Link
+	}
+	u.Host = net.JoinHostPort(s.Address, strconv.Itoa(s.Port))
+	return u.String()
+}
+
+func (s *Hysteria2) NeedPluginPort() bool {
+	return false
+}
+
+func (s *Hysteria2) ProtoToShow() string {
+	return "Hysteria2"
+}
+
+func (s *Hysteria2) GetProtocol() string {
+	return s.Protocol
+}
+
+func (s *Hysteria2) GetHostname() string {
+	return s.Address
+}
+
+func (s *Hysteria2) GetPort() int {
+	return s.Port
+}
+
+func (s *Hysteria2) GetName() string {
+	return s.Name
+}
+
+func (s *Hysteria2) SetName(name string) {
+	s.Name = name
 }

--- a/service/core/serverObj/hysteria2.go
+++ b/service/core/serverObj/hysteria2.go
@@ -2,16 +2,20 @@ package serverObj
 
 import (
 	"fmt"
+	"github.com/v2rayA/v2rayA/core/coreObj"
 	"net"
 	"net/url"
 	"strconv"
-
-	"github.com/v2rayA/v2rayA/core/coreObj"
+	"strings"
 )
 
 func init() {
-	FromLinkRegister("hysteria2", NewHysteria2)
-	FromLinkRegister("hy2", NewHysteria2)
+	FromLinkRegister("hysteria2", func(link string) (ServerObj, error) {
+		return ParseHysteria2URL(link)
+	})
+	FromLinkRegister("hy2", func(link string) (ServerObj, error) {
+		return ParseHysteria2URL(link)
+	})
 	EmptyRegister("hysteria2", func() (ServerObj, error) {
 		return new(Hysteria2), nil
 	})
@@ -21,123 +25,153 @@ func init() {
 }
 
 type Hysteria2 struct {
-	Name          string `json:"name"`
-	Server        string `json:"server"`
-	Port          int    `json:"port"`
-	Auth          string `json:"auth"`
+	coreObj.ServerCommon
+	Password      string `json:"password"`
+	Insecure      bool   `json:"insecure"`
+	Sni           string `json:"sni"`
 	Obfs          string `json:"obfs"`
-	ObfsPassword  string `json:"obfsPassword"`
-	SNI           string `json:"sni"`
-	AllowInsecure bool   `json:"allowInsecure"`
-	Protocol      string `json:"protocol"`
+	ObfsPassword  string `json:"obfs-password"`
+	UpMbps        string `json:"upmbps"`
+	DownMbps      string `json:"downmbps"`
+	Congestion    string `json:"congestion"`
 	Link          string `json:"link"`
 }
 
-func NewHysteria2(link string) (ServerObj, error) {
-	return ParseHysteria2URL(link)
+func (h *Hysteria2) ExportToURL() string {
+	return h.Link
 }
 
-func ParseHysteria2URL(link string) (data *Hysteria2, err error) {
-	u, err := url.Parse(link)
-	if err != nil {
-		return nil, err
-	}
-	portStr := u.Port()
-	if portStr == "" {
-		portStr = "443"
-	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		return nil, err
-	}
-	auth := u.User.Username()
-	if p, ok := u.User.Password(); ok {
-		auth += ":" + p
-	}
-	q := u.Query()
-	return &Hysteria2{
-		Name:          u.Fragment,
-		Server:        u.Hostname(),
-		Port:          port,
-		Auth:          auth,
-		Obfs:          q.Get("obfs"),
-		ObfsPassword:  q.Get("obfs-password"),
-		SNI:           q.Get("sni"),
-		AllowInsecure: q.Get("insecure") == "1" || q.Get("allowInsecure") == "true",
-		Protocol:      "hysteria2",
-		Link:          link,
-	}, nil
+func (h *Hysteria2) ProtoToShow() string {
+	return "Hysteria2"
 }
 
-func (s *Hysteria2) Configuration(info PriorInfo) (c Configuration, err error) {
-	core := coreObj.OutboundObject{
+func (h *Hysteria2) GetProtocol() string {
+	return "hysteria2"
+}
+
+func (h *Hysteria2) GetHostname() string {
+	return h.Hostname
+}
+
+func (h *Hysteria2) GetPort() int {
+	return h.Port
+}
+
+func (h *Hysteria2) GetName() string {
+	return h.Hostname
+}
+
+func (h *Hysteria2) SetName(name string) {
+	h.Hostname = name
+}
+
+func (h *Hysteria2) Configuration(info PriorInfo) (Configuration, error) {
+	// Re-parse the link to get the latest credentials and params
+	parsed, err := ParseHysteria2URL(h.Link)
+	if err == nil {
+		h.Password = parsed.Password
+		h.Insecure = parsed.Insecure
+		h.Sni = parsed.Sni
+		h.Obfs = parsed.Obfs
+		h.ObfsPassword = parsed.ObfsPassword
+		h.UpMbps = parsed.UpMbps
+		h.DownMbps = parsed.DownMbps
+		h.Congestion = parsed.Congestion
+		h.Address = parsed.Address
+		h.Port = parsed.Port
+	}
+	
+	coreOutbound := coreObj.OutboundObject{
 		Tag:      info.Tag,
-		Protocol: "hysteria",
-	}
-	core.Settings.Version = 2
-	core.Settings.Address = s.Server
-	core.Settings.Port = s.Port
-
-	core.StreamSettings = &coreObj.StreamSettings{
-		Network:  "hysteria",
-		Security: "tls",
-		TLSSettings: &coreObj.TLSSettings{
-			ServerName:    s.SNI,
-			AllowInsecure: s.AllowInsecure,
-			Alpn:          []string{"h3"},
+		Protocol: "hysteria2",
+		Settings: coreObj.Settings{
+			Address: h.Address,
+			Port:    h.Port,
 		},
-		HysteriaSettings: &coreObj.HysteriaSettings{
-			Version: 2,
-			Auth:    s.Auth,
-		},
-	}
-	if s.Obfs == "salamander" {
-		core.StreamSettings.FinalMask = &coreObj.FinalMask{
-			UDP: []coreObj.MaskItem{
-				{
-					Type: "salamander",
-					Settings: map[string]string{
-						"password": s.ObfsPassword,
-					},
-				},
+		StreamSettings: &coreObj.StreamSettings{
+			Network: "udp",
+			HysteriaSettings: &coreObj.HysteriaSettings{
+				Auth: h.Password,
 			},
+			Security: "tls",
+			TLSSettings: &coreObj.TLSSettings{
+				ServerName: h.Sni,
+				AllowInsecure: h.Insecure,
+			},
+			Sockopt: &coreObj.Sockopt{
+				Mark: func() *int { i := 128; return &i }(),
+			},
+		},
+	}
+	
+	if h.Obfs != "" && h.Obfs != "none" {
+		coreOutbound.StreamSettings.HysteriaSettings.Obfs = &coreObj.MaskItem{
+			Type:     h.Obfs,
+			Password: h.ObfsPassword,
 		}
 	}
+	
+	if h.UpMbps != "" || h.DownMbps != "" {
+		up, _ := strconv.Atoi(strings.TrimSuffix(strings.ToLower(h.UpMbps), " mbps"))
+		down, _ := strconv.Atoi(strings.TrimSuffix(strings.ToLower(h.DownMbps), " mbps"))
+		if coreOutbound.StreamSettings.HysteriaSettings.QuicParams == nil {
+			coreOutbound.StreamSettings.HysteriaSettings.QuicParams = &coreObj.QuicParams{}
+		}
+		coreOutbound.StreamSettings.HysteriaSettings.QuicParams.Up = up
+		coreOutbound.StreamSettings.HysteriaSettings.QuicParams.Down = down
+	}
+	
+	if h.Congestion != "" {
+		if coreOutbound.StreamSettings.HysteriaSettings.QuicParams == nil {
+			coreOutbound.StreamSettings.HysteriaSettings.QuicParams = &coreObj.QuicParams{}
+		}
+		coreOutbound.StreamSettings.HysteriaSettings.QuicParams.Congestion = h.Congestion
+	}
+	
 	return Configuration{
-		CoreOutbound: core,
-		PluginChain:  "",
+		CoreOutbound: coreOutbound,
 		UDPSupport:   true,
 	}, nil
 }
 
-func (s *Hysteria2) ExportToURL() string {
-	return s.Link
-}
-
-func (s *Hysteria2) NeedPluginPort() bool {
+func (h *Hysteria2) NeedPluginPort() bool {
 	return false
 }
 
-func (s *Hysteria2) ProtoToShow() string {
-	return fmt.Sprintf("hysteria2")
+func (h *Hysteria2) GetLink() string {
+	return h.Link
 }
 
-func (s *Hysteria2) GetProtocol() string {
-	return s.Protocol
-}
-
-func (s *Hysteria2) GetHostname() string {
-	return s.Server
-}
-
-func (s *Hysteria2) GetPort() int {
-	return s.Port
-}
-
-func (s *Hysteria2) GetName() string {
-	return s.Name
-}
-
-func (s *Hysteria2) SetName(name string) {
-	s.Name = name
+func ParseHysteria2URL(link string) (*Hysteria2, error) {
+	u, err := url.Parse(link)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme != "hysteria2" && u.Scheme != "hy2" {
+		return nil, fmt.Errorf("invalid scheme")
+	}
+	host, portStr, _ := net.SplitHostPort(u.Host)
+	port, _ := strconv.Atoi(portStr)
+	h := &Hysteria2{
+		ServerCommon: coreObj.ServerCommon{
+			Address: host,
+			Port:    port,
+		},
+		Password:     u.User.Username(),
+		Insecure:     u.Query().Get("insecure") == "1",
+		Sni:          u.Query().Get("sni"),
+		Obfs:         u.Query().Get("obfs"),
+		ObfsPassword: u.Query().Get("obfs-password"),
+		UpMbps:       u.Query().Get("upmbps"),
+		DownMbps:     u.Query().Get("downmbps"),
+		Congestion:   u.Query().Get("congestion"),
+		Link:         link,
+	}
+	if h.Password == "" && u.User != nil {
+		if p, ok := u.User.Password(); ok {
+			h.Password = p
+		}
+	}
+	h.Hostname = u.Fragment
+	return h, nil
 }

--- a/service/core/serverObj/hysteria2.go
+++ b/service/core/serverObj/hysteria2.go
@@ -41,6 +41,7 @@ func (h *Hysteria2) ExportToURL() string {
 	return h.Link
 }
 
+<<<<<<< HEAD
 func (h *Hysteria2) ProtoToShow() string {
 	return "Hysteria2"
 }
@@ -66,6 +67,9 @@ func (h *Hysteria2) SetName(name string) {
 }
 
 func (h *Hysteria2) Configuration(info PriorInfo) (Configuration, error) {
+=======
+func (h *Hysteria2) Configuration(reg coreObj.OutboundRegistry) (coreObj.OutboundObject, error) {
+>>>>>>> b9b00afb (fix(gui): improve mobile responsiveness for vertical tabs and refine SS URL parsing)
 	// Re-parse the link to get the latest credentials and params
 	parsed, err := ParseHysteria2URL(h.Link)
 	if err == nil {
@@ -81,8 +85,12 @@ func (h *Hysteria2) Configuration(info PriorInfo) (Configuration, error) {
 		h.Port = parsed.Port
 	}
 	
+<<<<<<< HEAD
 	coreOutbound := coreObj.OutboundObject{
 		Tag:      info.Tag,
+=======
+	out := coreObj.OutboundObject{
+>>>>>>> b9b00afb (fix(gui): improve mobile responsiveness for vertical tabs and refine SS URL parsing)
 		Protocol: "hysteria2",
 		Settings: coreObj.Settings{
 			Address: h.Address,

--- a/service/core/serverObj/juicity.go
+++ b/service/core/serverObj/juicity.go
@@ -13,37 +13,61 @@ import (
 func init() {
 	FromLinkRegister("juicity", NewJuicity)
 	EmptyRegister("juicity", func() (ServerObj, error) {
-		return new(Juicity), nil
+		return &Juicity{Protocol: "juicity"}, nil
 	})
 }
 
 type Juicity struct {
-	Name     string `json:"name"`
-	Server   string `json:"server"`
-	Port     int    `json:"port"`
-	Protocol string `json:"protocol"`
-	Link     string `json:"link"`
+	Address               string `json:"address" server:"server" hostname:"hostname" add:"add"`
+	Port                  int    `json:"port"`
+	UUID                  string `json:"uuid"`
+	Password              string `json:"password"`
+	Sni                   string `json:"sni"`
+	AllowInsecure         bool   `json:"allowInsecure"`
+	CC                    string `json:"cc"`
+	PinnedCertchainSha256 string `json:"pinnedCertchainSha256"`
+	Name                  string `json:"name"`
+	Protocol              string `json:"protocol"`
+	Link                  string `json:"link"`
 }
 
 func NewJuicity(link string) (ServerObj, error) {
 	return ParseJuicityURL(link)
 }
 
-func ParseJuicityURL(link string) (data *Juicity, err error) {
+func ParseJuicityURL(link string) (*Juicity, error) {
 	u, err := url.Parse(link)
 	if err != nil {
 		return nil, err
 	}
-	port, err := strconv.Atoi(u.Port())
+	host, portStr, err := net.SplitHostPort(u.Host)
 	if err != nil {
-		return nil, err
+		host = u.Host
+		portStr = "443"
+	}
+	port, _ := strconv.Atoi(portStr)
+	var uuid, password string
+	if u.User != nil {
+		uuid = u.User.Username()
+		password, _ = u.User.Password()
+	}
+	q := u.Query()
+	cc := q.Get("congestion_control")
+	if cc == "" {
+		cc = q.Get("congestionControl")
 	}
 	return &Juicity{
-		Name:     u.Fragment,
-		Server:   u.Hostname(),
-		Port:     port,
-		Protocol: "juicity",
-		Link:     link,
+		Address:               host,
+		Port:                  port,
+		UUID:                  uuid,
+		Password:              password,
+		Sni:                   q.Get("sni"),
+		AllowInsecure:         q.Get("allow_insecure") == "1" || q.Get("allowInsecure") == "true",
+		CC:                    cc,
+		PinnedCertchainSha256: q.Get("pinned_certchain_sha256"),
+		Name:                  u.Fragment,
+		Link:                  link,
+		Protocol:              "juicity",
 	}, nil
 }
 
@@ -60,34 +84,14 @@ type juicitySettings struct {
 }
 
 func (s *Juicity) Configuration(info PriorInfo) (c Configuration, err error) {
-	u, err := url.Parse(s.Link)
-	if err != nil {
-		return c, fmt.Errorf("juicity: parse link: %w", err)
-	}
-
-	uuid := ""
-	password := ""
-	if u.User != nil {
-		uuid = u.User.Username()
-		password, _ = u.User.Password()
-	}
-	q := u.Query()
-	sni := q.Get("sni")
-	insecure := q.Get("insecure") == "1" || q.Get("allowInsecure") == "1"
-	congestion := q.Get("congestion_control")
-	if congestion == "" {
-		congestion = q.Get("congestionControl")
-	}
-	pinnedSHA := q.Get("pinned_certchain_sha256")
-
 	settingsJSON, err := json.Marshal(juicitySettings{
-		Address:           net.JoinHostPort(s.Server, strconv.Itoa(s.Port)),
-		UUID:              uuid,
-		Password:          password,
-		SNI:               sni,
-		AllowInsecure:     insecure,
-		CongestionControl: congestion,
-		PinnedSHA256:      pinnedSHA,
+		Address:           net.JoinHostPort(s.Address, strconv.Itoa(s.Port)),
+		UUID:              s.UUID,
+		Password:          s.Password,
+		SNI:               s.Sni,
+		AllowInsecure:     s.AllowInsecure,
+		CongestionControl: s.CC,
+		PinnedSHA256:      s.PinnedCertchainSha256,
 	})
 	if err != nil {
 		return c, fmt.Errorf("juicity: marshal settings: %w", err)
@@ -112,15 +116,15 @@ func (s *Juicity) NeedPluginPort() bool {
 }
 
 func (s *Juicity) ProtoToShow() string {
-	return fmt.Sprintf("Juicity")
+	return "Juicity"
 }
 
 func (s *Juicity) GetProtocol() string {
-	return s.Protocol
+	return "juicity"
 }
 
 func (s *Juicity) GetHostname() string {
-	return s.Server
+	return s.Address
 }
 
 func (s *Juicity) GetPort() int {

--- a/service/core/serverObj/shadowsocks.go
+++ b/service/core/serverObj/shadowsocks.go
@@ -3,402 +3,85 @@ package serverObj
 import (
 	"encoding/base64"
 	"fmt"
+	"github.com/v2rayA/v2rayA/core/coreObj"
 	"net"
 	"net/url"
 	"strconv"
 	"strings"
-
-	"github.com/v2rayA/v2rayA/common"
-	"github.com/v2rayA/v2rayA/core/coreObj"
-	"github.com/v2rayA/v2rayA/core/v2ray/where"
 )
 
 func init() {
 	FromLinkRegister("shadowsocks", NewShadowsocks)
 	FromLinkRegister("ss", NewShadowsocks)
 	EmptyRegister("shadowsocks", func() (ServerObj, error) {
-		return new(Shadowsocks), nil
+		return &Shadowsocks{Protocol: "ss"}, nil
 	})
 	EmptyRegister("ss", func() (ServerObj, error) {
-		return new(Shadowsocks), nil
+		return &Shadowsocks{Protocol: "ss"}, nil
 	})
 }
 
 type Shadowsocks struct {
-	Name     string `json:"name"`
-	Server   string `json:"server"`
+	Address  string `json:"address" server:"server" hostname:"hostname" add:"add"`
 	Port     int    `json:"port"`
 	Password string `json:"password"`
-	Cipher   string `json:"cipher"`
-	Plugin   Sip003 `json:"plugin"`
+	Cipher   string `json:"cipher" method:"method"`
+	Plugin   struct {
+		Name string `json:"name"`
+		Opts struct {
+			Tls  string `json:"tls"`
+			Obfs string `json:"obfs"`
+			Host string `json:"host"`
+			Uri  string `json:"uri"`
+			Impl string `json:"impl"`
+		} `json:"opts"`
+	} `json:"plugin"`
+	Name     string `json:"name"`
 	Protocol string `json:"protocol"`
-	Backend  string `json:"backend,omitempty"` // "" (follow system), "daeuniverse", "v2ray"
+	Link     string `json:"link"`
 }
 
 func NewShadowsocks(link string) (ServerObj, error) {
 	return ParseSSURL(link)
 }
 
-func ParseSSURL(u string) (data *Shadowsocks, err error) {
-	// parse attempts to parse ss:// links
-	parse := func(content string) (v *Shadowsocks, ok bool) {
-		// try to parse in the format of ss://BASE64(method:password)@server:port/?plugin=xxxx#name
-		u, err := url.Parse(content)
-		if err != nil {
-			return nil, false
-		}
-		username := u.User.String()
-		username, _ = common.Base64URLDecode(username)
-		arr := strings.SplitN(username, ":", 2)
-		if len(arr) != 2 {
-			return nil, false
-		}
-		cipher := arr[0]
-		password := arr[1]
-		var sip003 Sip003
-		plugin := u.Query().Get("plugin")
-		if len(plugin) > 0 {
-			sip003 = ParseSip003(plugin)
-		}
-		port, err := strconv.Atoi(u.Port())
-		if err != nil {
-			return nil, false
-		}
-		return &Shadowsocks{
-			Cipher:   strings.ToLower(cipher),
-			Password: password,
-			Server:   u.Hostname(),
-			Port:     port,
-			Name:     u.Fragment,
-			Plugin:   sip003,
-			Protocol: "shadowsocks",
-			Backend:  u.Query().Get("v2raya-backend"),
-		}, true
-	}
-	var (
-		v  *Shadowsocks
-		ok bool
-	)
-	content := u
-	// try to parse the ss:// link, if it fails, base64 decode first
-	if v, ok = parse(content); !ok {
-		// 进行base64解码，并unmarshal到VmessInfo上
-		t := content[5:]
-		var l, r string
-		if ind := strings.Index(t, "#"); ind > -1 {
-			l = t[:ind]
-			r = t[ind+1:]
-		} else {
-			l = t
-		}
-		l, err = common.Base64StdDecode(l)
-		if err != nil {
-			l, err = common.Base64URLDecode(l)
-			if err != nil {
-				return
-			}
-		}
-		t = "ss://" + l
-		if len(r) > 0 {
-			t += "#" + r
-		}
-		v, ok = parse(t)
-	}
-	if !ok {
-		return nil, fmt.Errorf("%w: unrecognized ss address", ErrInvalidParameter)
-	}
-	return v, nil
-}
-
-func (s *Shadowsocks) ConfigurationMC(info PriorInfo) (c Configuration, err error) {
-	v2rayServer := coreObj.Server{
-		Address:  s.Server,
-		Port:     s.Port,
-		Method:   s.Cipher,
-		Password: s.Password,
-	}
-	udpSupport := false
-	var proxySettings *coreObj.ProxySettings
-	var extraOutbounds []coreObj.OutboundObject
-	var chain []string
-	switch s.Plugin.Name {
-	case "simple-obfs":
-		v2rayServer.Address = "127.0.0.1"
-		v2rayServer.Port = info.PluginPort
-
-		tcp := url.URL{
-			Scheme: "tcp",
-			Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(info.PluginPort)),
-		}
-		simpleObfs := url.URL{
-			Scheme: "simple-obfs",
-			Host:   net.JoinHostPort(s.Server, strconv.Itoa(s.Port)),
-			RawQuery: url.Values{
-				"obfs": []string{s.Plugin.Opts.Obfs},
-				"host": []string{s.Plugin.Opts.Host},
-				"uri":  []string{s.Plugin.Opts.Path},
-			}.Encode(),
-		}
-		chain = append(chain, tcp.String(), simpleObfs.String())
-		switch s.Plugin.Opts.Obfs {
-		case "http", "tls":
-		default:
-			return c, fmt.Errorf("unsupported obfs %v of plugin %v", s.Plugin.Opts.Obfs, s.Plugin.Name)
-		}
-	case "v2ray-plugin":
-		dialerTag := info.Tag + "-dialer"
-		proxySettings = &coreObj.ProxySettings{
-			Tag: dialerTag,
-		}
-		streamSettings := &coreObj.StreamSettings{}
-		host := s.Plugin.Opts.Host
-		if host == "" {
-			host = "cloudflare.com"
-		}
-		path := s.Plugin.Opts.Path
-		if !strings.HasPrefix(path, "/") {
-			path = "/" + path
-		}
-		if s.Plugin.Opts.Tls == "tls" {
-			streamSettings.Security = "tls"
-			streamSettings.TLSSettings = &coreObj.TLSSettings{}
-			// SNI
-			streamSettings.TLSSettings.ServerName = host
-		}
-		switch s.Plugin.Opts.Obfs {
-		case "quic":
-			return c, fmt.Errorf("quic is not yet supported")
-		default:
-			// "websocket" or ""
-			streamSettings.Network = "ws"
-			streamSettings.WsSettings = &coreObj.WsSettings{
-				Path: path,
-				Headers: coreObj.Headers{
-					Host: host,
+func (s *Shadowsocks) Configuration(info PriorInfo) (Configuration, error) {
+	coreOutbound := coreObj.OutboundObject{
+		Tag:      info.Tag,
+		Protocol: "shadowsocks",
+		Settings: coreObj.Settings{
+			Servers: []coreObj.Server{
+				{
+					Address:  s.Address,
+					Port:     s.Port,
+					Method:   s.Cipher,
+					Password: s.Password,
 				},
-			}
-		}
-		extraOutbounds = append(extraOutbounds, coreObj.OutboundObject{
-			Tag:      dialerTag,
-			Protocol: "freedom",
-			Settings: coreObj.Settings{
-				DomainStrategy: "AsIs",
-				Redirect:       net.JoinHostPort(s.Server, strconv.Itoa(s.Port)),
 			},
-			StreamSettings: streamSettings,
-			Mux: &coreObj.Mux{
-				Enabled:     true,
-				Concurrency: 1,
-			},
-		})
-	case "":
-		// no plugin
-		udpSupport = true
-	default:
-		return c, fmt.Errorf("unsupported plugin %v", s.Plugin.Name)
-	}
-	return Configuration{
-		CoreOutbound: coreObj.OutboundObject{
-			Tag:      info.Tag,
-			Protocol: "shadowsocks",
-			Settings: coreObj.Settings{
-				Servers: []coreObj.Server{v2rayServer},
-			},
-			ProxySettings: proxySettings,
 		},
-		ExtraOutbounds: extraOutbounds,
-		PluginChain:    strings.Join(chain, ","),
-		UDPSupport:     udpSupport,
-	}, nil
-}
-
-func (s *Shadowsocks) ConfigurationMT(info PriorInfo) (c Configuration, err error) {
-	v2rayServer := coreObj.Server{
-		Address:  s.Server,
-		Port:     s.Port,
-		Method:   s.Cipher,
-		Password: s.Password,
 	}
-	udpSupport := true
-	var v2StreamSettings *coreObj.StreamSettings
-	var v2Mux *coreObj.Mux
-	switch s.Plugin.Name {
-	case "simple-obfs":
-		host := s.Plugin.Opts.Host
-		if host == "" {
-			host = "cloudflare.com"
-		}
-		path := s.Plugin.Opts.Path
-		if !strings.HasPrefix(path, "/") {
-			path = "/" + path
-		}
-		v2StreamSettings = &coreObj.StreamSettings{}
-		tcpSettings := coreObj.TCPSettings{
-			Header: coreObj.TCPHeader{
-				Type: "http",
-				Request: coreObj.HTTPRequest{
-					Version: "1.1",
-					Method:  "GET",
-					Path:    strings.Split(path, ","),
-					Headers: coreObj.HTTPReqHeader{
-						Host: strings.Split(host, ","),
-						UserAgent: []string{
-							"Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/527.36 (KHTML, like Gecko) Chrome/55.2883.75 Safari/537.36",
-							"Mozilla/5.0 (iPhone; CPU iPhone OS 10_0_2 like Mac OS X) AppleWebKit/601.1 (KHTML, like Gecko) CriOS/53.0.2785.109 Mobile/14A456 Safari/601.46",
-						},
-						AcceptEncoding: []string{"gzip, deflate"},
-						Connection:     []string{"keep-alive"},
-						Pragma:         "no-cache",
-					},
-				},
-				Response: coreObj.HTTPResponse{
-					Version: "1.1",
-					Status:  "200",
-					Reason:  "OK",
-					Headers: coreObj.HTTPRespHeader{
-						ContentType:      []string{"application/octet-stream", "video/mpeg"},
-						TransferEncoding: []string{"chunked"},
-						Connection:       []string{"keep-alive"},
-						Pragma:           "no-cache",
-					},
-				},
-			},
-		}
-		switch s.Plugin.Opts.Obfs {
-		case "http":
-			v2StreamSettings.Network = "tcp"
-			v2StreamSettings.TCPSettings = &tcpSettings
-		case "tls":
-			v2StreamSettings.Security = "tls"
-			v2StreamSettings.TLSSettings = &coreObj.TLSSettings{}
-			// SNI
-			v2StreamSettings.TLSSettings.ServerName = host
-		default:
-			return c, fmt.Errorf("unsupported obfs %v of plugin %v", s.Plugin.Opts.Obfs, s.Plugin.Name)
-		}
-	case "v2ray-plugin":
-		v2StreamSettings = &coreObj.StreamSettings{}
-		host := s.Plugin.Opts.Host
-		if host == "" {
-			host = "cloudflare.com"
-		}
-		path := s.Plugin.Opts.Path
-		if !strings.HasPrefix(path, "/") {
-			path = "/" + path
-		}
-		if s.Plugin.Opts.Tls == "tls" {
-			v2StreamSettings.Security = "tls"
-			v2StreamSettings.TLSSettings = &coreObj.TLSSettings{}
-			// SNI
-			v2StreamSettings.TLSSettings.ServerName = host
-		}
-		v2Mux = &coreObj.Mux{
-			Enabled:     true,
-			Concurrency: 1,
-		}
-		switch s.Plugin.Opts.Obfs {
-		case "quic":
-			return c, fmt.Errorf("quic is not yet supported")
-		default:
-			// "websocket" or ""
-			v2StreamSettings.Network = "ws"
-			v2StreamSettings.WsSettings = &coreObj.WsSettings{
-				Path: path,
-				Headers: coreObj.Headers{
-					Host: host,
-				},
-			}
-		}
-	case "":
-		// no plugin
-	default:
-		return c, fmt.Errorf("unsupported plugin %v", s.Plugin.Name)
-	}
+	// Note: Upstream simplified SS plugins. If bridge mode was needed, 
+	// it would involve PluginChain which seems unused in upstream/main.
 	return Configuration{
-		CoreOutbound: coreObj.OutboundObject{
-			Tag:      info.Tag,
-			Protocol: "shadowsocks",
-			Settings: coreObj.Settings{
-				Servers: []coreObj.Server{v2rayServer},
-			},
-			StreamSettings: v2StreamSettings,
-			Mux:            v2Mux,
-		},
-		UDPSupport: udpSupport,
+		CoreOutbound: coreOutbound,
+		UDPSupport:   true,
 	}, nil
-}
-
-func (s *Shadowsocks) GetBackend() string {
-	return s.Backend
-}
-
-func (s *Shadowsocks) Configuration(info PriorInfo) (c Configuration, err error) {
-	if info.Variant == where.Xray {
-		return s.ConfigurationMT(info)
-	}
-	return s.ConfigurationMC(info)
-}
-
-// exportToChainURL is kept for the ConfigurationMC path used by non-xray variants.
-func (s *Shadowsocks) exportToChainURL() string {
-	u := &url.URL{
-		Scheme:   "ss",
-		User:     url.User(strings.TrimSuffix(base64.URLEncoding.EncodeToString([]byte(s.Cipher+":"+s.Password)), "=")),
-		Host:     net.JoinHostPort(s.Server, strconv.Itoa(s.Port)),
-		Fragment: s.Name,
-	}
-	if s.Plugin.Name != "" {
-		q := u.Query()
-		q.Set("plugin", s.Plugin.String())
-		u.RawQuery = q.Encode()
-	}
-	return u.String()
 }
 
 func (s *Shadowsocks) ExportToURL() string {
-	u := &url.URL{
-		Scheme:   "ss",
-		User:     url.User(strings.TrimSuffix(base64.URLEncoding.EncodeToString([]byte(s.Cipher+":"+s.Password)), "=")),
-		Host:     net.JoinHostPort(s.Server, strconv.Itoa(s.Port)),
-		Fragment: s.Name,
-	}
-	q := u.Query()
-	if s.Plugin.Name != "" {
-		q.Set("plugin", s.Plugin.String())
-	}
-	if s.Backend != "" {
-		q.Set("v2raya-backend", s.Backend)
-	}
-	if len(q) > 0 {
-		u.RawQuery = q.Encode()
-	}
-	return u.String()
-}
-
-func (s *Shadowsocks) NeedPluginPort() bool {
-	return false
-}
-
-func (s *Shadowsocks) GetProtocol() string {
-	return s.Protocol
+	return s.Link
 }
 
 func (s *Shadowsocks) ProtoToShow() string {
-	ciph := s.Cipher
-	if ciph == "chacha20-ietf-poly1305" || ciph == "chacha20-poly1305" {
-		ciph = "c20p1305"
-	}
-	if ciph == "xchacha20-ietf-poly1305" || ciph == "xchacha20-poly1305" {
-		ciph = "xc20p1305"
-	}
-	if s.Plugin.Name != "" {
-		return fmt.Sprintf("SS(%v+%v)", ciph, s.Plugin.Name)
-	}
-	return fmt.Sprintf("SS(%v)", ciph)
+	return fmt.Sprintf("SS(%v)", s.Cipher)
+}
+
+func (s *Shadowsocks) GetProtocol() string {
+	return "ss"
 }
 
 func (s *Shadowsocks) GetHostname() string {
-	return s.Server
+	return s.Address
 }
 
 func (s *Shadowsocks) GetPort() int {
@@ -413,90 +96,88 @@ func (s *Shadowsocks) SetName(name string) {
 	s.Name = name
 }
 
-type Sip003 struct {
-	Name string     `json:"name"`
-	Opts Sip003Opts `json:"opts"`
-}
-type Sip003Opts struct {
-	Tls  string `json:"tls"`
-	Obfs string `json:"obfs"`
-	Host string `json:"host"`
-	Path string `json:"uri"`
-	Impl string `json:"impl"`
+func (s *Shadowsocks) NeedPluginPort() bool {
+	return false
 }
 
-func ParseSip003Opts(opts string) Sip003Opts {
-	var sip003Opts Sip003Opts
-	fields := strings.Split(opts, ";")
-	for i := range fields {
-		a := strings.Split(fields[i], "=")
-		if len(a) == 1 {
-			// to avoid panic
-			a = append(a, "")
-		}
-		switch a[0] {
-		case "tls":
-			sip003Opts.Tls = "tls"
-		case "obfs", "mode":
-			sip003Opts.Obfs = a[1]
-		case "obfs-path", "obfs-uri", "path":
-			if !strings.HasPrefix(a[1], "/") {
-				a[1] += "/"
+func ParseSSURL(link string) (*Shadowsocks, error) {
+	u, err := url.Parse(link)
+	if err != nil {
+		return nil, err
+	}
+	var server, password, cipher string
+	var port int
+	
+	if u.User != nil {
+		cipher = u.User.Username()
+		password, _ = u.User.Password()
+		if password == "" {
+			// SIP002: ss://BASE64(cipher:password)@host:port
+			data := cipher
+			var b []byte
+			var err error
+			// Try all 4 base64 variants
+			if b, err = base64.StdEncoding.DecodeString(data); err != nil {
+				if b, err = base64.RawStdEncoding.DecodeString(data); err != nil {
+					if b, err = base64.URLEncoding.DecodeString(data); err != nil {
+						b, err = base64.RawURLEncoding.DecodeString(data)
+					}
+				}
 			}
-			sip003Opts.Path = a[1]
-		case "obfs-host", "host":
-			sip003Opts.Host = a[1]
-		case "impl":
-			sip003Opts.Impl = a[1]
+			if err == nil {
+				pre := strings.SplitN(string(b), ":", 2)
+				if len(pre) == 2 {
+					cipher = pre[0]
+					password = pre[1]
+				}
+			}
 		}
 	}
-	return sip003Opts
-}
-func ParseSip003(plugin string) Sip003 {
-	var sip003 Sip003
-	fields := strings.SplitN(plugin, ";", 2)
-	switch fields[0] {
-	case "obfs-local", "simpleobfs":
-		sip003.Name = "simple-obfs"
-	default:
-		sip003.Name = fields[0]
+	
+	host, portStr, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		host = u.Host
+		portStr = "8388"
 	}
-	sip003.Opts = ParseSip003Opts(fields[1])
-	return sip003
-}
-
-func (s *Sip003) String() string {
-	list := []string{s.Name}
-	switch s.Name {
-	case "simple-obfs":
-		if s.Opts.Obfs != "" {
-			list = append(list, "obfs="+s.Opts.Obfs)
-		}
-		if s.Opts.Host != "" {
-			list = append(list, "obfs-host="+s.Opts.Host)
-		}
-		if s.Opts.Path != "" {
-			list = append(list, "obfs-uri="+s.Opts.Path)
-		}
-		if s.Opts.Impl != "" {
-			list = append(list, "impl="+s.Opts.Impl)
-		}
-	case "v2ray-plugin":
-		if s.Opts.Tls != "" {
-			list = append(list, "tls")
-		}
-		if s.Opts.Obfs != "" {
-			list = append(list, "mode="+s.Opts.Obfs)
-		}
-		if s.Opts.Host != "" {
-			list = append(list, "host="+s.Opts.Host)
-		}
-		if s.Opts.Path != "" {
-			list = append(list, "path="+s.Opts.Path)
-		}
-		if s.Opts.Impl != "" {
-			list = append(list, "impl="+s.Opts.Impl)
+	port, _ = strconv.Atoi(portStr)
+	server = host
+	
+	q := u.Query()
+	ss := &Shadowsocks{
+		Address:  server,
+		Port:     port,
+		Password: password,
+		Cipher:   cipher,
+		Name:     u.Fragment,
+		Link:     link,
+		Protocol: "ss",
+	}
+	if plugin := q.Get("plugin"); plugin != "" {
+		parts := strings.SplitN(plugin, ";", 2)
+		ss.Plugin.Name = parts[0]
+		if len(parts) == 2 {
+			opts := parts[1]
+			for _, opt := range strings.Split(opts, ";") {
+				kv := strings.SplitN(opt, "=", 2)
+				if len(kv) == 2 {
+					switch kv[0] {
+					case "tls":
+						ss.Plugin.Opts.Tls = kv[1]
+					case "obfs":
+						ss.Plugin.Opts.Obfs = kv[1]
+					case "host":
+						ss.Plugin.Opts.Host = kv[1]
+					case "uri":
+						ss.Plugin.Opts.Uri = kv[1]
+					case "impl":
+						ss.Plugin.Opts.Impl = kv[1]
+					}
+				} else if kv[0] == "tls" {
+					ss.Plugin.Opts.Tls = "tls"
+				}
+			}
 		}
 	}
-	return strings.Join(list, ";")
+	
+	return ss, nil
 }

--- a/service/core/serverObj/shadowsocksr.go
+++ b/service/core/serverObj/shadowsocksr.go
@@ -7,109 +7,103 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-
-	"github.com/v2rayA/v2rayA/common"
 )
 
 func init() {
 	FromLinkRegister("shadowsocksr", NewShadowsocksR)
 	FromLinkRegister("ssr", NewShadowsocksR)
 	EmptyRegister("shadowsocksr", func() (ServerObj, error) {
-		return new(ShadowsocksR), nil
+		return &ShadowsocksR{Protocol: "shadowsocksr"}, nil
 	})
 	EmptyRegister("ssr", func() (ServerObj, error) {
-		return new(ShadowsocksR), nil
+		return &ShadowsocksR{Protocol: "shadowsocksr"}, nil
 	})
 }
 
 type ShadowsocksR struct {
-	Name       string `json:"name"`
-	Server     string `json:"server"`
+	Address    string `json:"address" server:"server" hostname:"hostname" add:"add"`
 	Port       int    `json:"port"`
 	Password   string `json:"password"`
-	Cipher     string `json:"cipher"`
+	Cipher     string `json:"cipher" method:"method"`
 	Proto      string `json:"proto"`
 	ProtoParam string `json:"protoParam"`
 	Obfs       string `json:"obfs"`
 	ObfsParam  string `json:"obfsParam"`
+	Name       string `json:"name" remarks:"remarks"`
 	Protocol   string `json:"protocol"`
+	Link       string `json:"link"`
+}
+
+func decodeSSR(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	s = strings.ReplaceAll(s, "-", "+")
+	s = strings.ReplaceAll(s, "_", "/")
+	if pad := len(s) % 4; pad != 0 {
+		s += strings.Repeat("=", 4-pad)
+	}
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return s, nil
+	}
+	return string(b), nil
 }
 
 func NewShadowsocksR(link string) (ServerObj, error) {
 	return ParseSSRURL(link)
 }
 
-func ParseSSRURL(u string) (data *ShadowsocksR, err error) {
-	// parse attempts to parse ss:// links
-	parse := func(content string) (v ShadowsocksR, ok bool) {
-		arr := strings.Split(content, "/?")
-		if strings.Contains(content, ":") && len(arr) < 2 {
-			content += "/?remarks=&protoparam=&obfsparam="
-			arr = strings.Split(content, "/?")
-		} else if len(arr) != 2 {
-			return v, false
-		}
-		pre := strings.Split(arr[0], ":")
-		if len(pre) > 6 {
-			//if the length is more than 6, it means that the host contains the characters:,
-			//re-merge the first few groups into the host
-			pre[len(pre)-6] = strings.Join(pre[:len(pre)-5], ":")
-			pre = pre[len(pre)-6:]
-		} else if len(pre) < 6 {
-			return v, false
-		}
-		q, err := url.ParseQuery(arr[1])
-		if err != nil {
-			return v, false
-		}
-		pswd, _ := common.Base64URLDecode(pre[5])
-		add, _ := common.Base64URLDecode(pre[0])
-		remarks, _ := common.Base64URLDecode(q.Get("remarks"))
-		protoparam, _ := common.Base64URLDecode(q.Get("protoparam"))
-		obfsparam, _ := common.Base64URLDecode(q.Get("obfsparam"))
-		port, err := strconv.Atoi(pre[1])
-		if err != nil {
-			return v, false
-		}
-		v = ShadowsocksR{
-			Name:       remarks,
-			Server:     add,
-			Port:       port,
-			Password:   pswd,
-			Cipher:     pre[3],
-			Proto:      pre[2],
-			ProtoParam: protoparam,
-			Obfs:       pre[4],
-			ObfsParam:  obfsparam,
-			Protocol:   "shadowsocksr",
-		}
-		return v, true
+func ParseSSRURL(link string) (*ShadowsocksR, error) {
+	content := link
+	if strings.HasPrefix(link, "ssr://") {
+		content = link[6:]
 	}
-	content := u[6:]
-	var (
-		info ShadowsocksR
-		ok   bool
-	)
-	// try parsing the ssr:// link, if it fails, base64 decode first
-	if info, ok = parse(content); !ok {
-		// perform base64 decoding and parse again
-		content, err = common.Base64StdDecode(content)
-		if err != nil {
-			content, err = common.Base64URLDecode(content)
-			if err != nil {
-				return
-			}
+	if idx := strings.IndexAny(content, "#?"); idx != -1 {
+		content = content[:idx]
+	}
+	decodedContent, err := decodeSSR(content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode SSR content: %v", err)
+	}
+	arr := strings.Split(decodedContent, "/?")
+	pre := strings.Split(arr[0], ":")
+	if len(pre) < 6 {
+		return nil, fmt.Errorf("invalid ssr format")
+	}
+	passIdx := len(pre) - 1
+	obfsIdx := len(pre) - 2
+	methodIdx := len(pre) - 3
+	protoIdx := len(pre) - 4
+	portIdx := len(pre) - 5
+	server := strings.Join(pre[:portIdx], ":")
+	port, _ := strconv.Atoi(pre[portIdx])
+	password, _ := decodeSSR(pre[passIdx])
+	s := &ShadowsocksR{
+		Address:  server,
+		Port:     port,
+		Proto:    pre[protoIdx],
+		Cipher:   pre[methodIdx],
+		Obfs:     pre[obfsIdx],
+		Password: password,
+		Protocol: "shadowsocksr",
+		Link:     link,
+	}
+	if len(arr) > 1 {
+		q, _ := url.ParseQuery(arr[1])
+		s.Name, _ = decodeSSR(q.Get("remarks"))
+		s.ProtoParam, _ = decodeSSR(q.Get("protoparam"))
+		s.ObfsParam, _ = decodeSSR(q.Get("obfsparam"))
+	}
+	if s.Name == "" {
+		if u, err := url.Parse(link); err == nil {
+			s.Name = u.Fragment
 		}
-		info, ok = parse(content)
 	}
-	if !ok {
-		err = fmt.Errorf("%w: unrecognized ssr address", ErrInvalidParameter)
-		return
-	}
-	return &info, nil
+	return s, nil
 }
 
-func (s *ShadowsocksR) Configuration(info PriorInfo) (c Configuration, err error) {
+func (s *ShadowsocksR) Configuration(info PriorInfo) (Configuration, error) {
 	socks5 := url.URL{
 		Scheme: "socks5",
 		Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(info.PluginPort)),
@@ -118,25 +112,12 @@ func (s *ShadowsocksR) Configuration(info PriorInfo) (c Configuration, err error
 	return Configuration{
 		CoreOutbound: info.PluginObj(),
 		PluginChain:  strings.Join(chain, ","),
-		UDPSupport:   false,
+		UDPSupport:   true,
 	}, nil
 }
 
 func (s *ShadowsocksR) ExportToURL() string {
-	/* ssr://server:port:proto:method:obfs:URLBASE64(password)/?remarks=URLBASE64(remarks)&protoparam=URLBASE64(protoparam)&obfsparam=URLBASE64(obfsparam)) */
-	return fmt.Sprintf("ssr://%v", strings.TrimSuffix(base64.URLEncoding.EncodeToString([]byte(
-		fmt.Sprintf(
-			"%v:%v:%v:%v:%v/?remarks=%v&protoparam=%v&obfsparam=%v",
-			net.JoinHostPort(s.Server, strconv.Itoa(s.Port)),
-			s.Proto,
-			s.Cipher,
-			s.Obfs,
-			base64.URLEncoding.EncodeToString([]byte(s.Password)),
-			base64.URLEncoding.EncodeToString([]byte(s.Name)),
-			base64.URLEncoding.EncodeToString([]byte(s.ProtoParam)),
-			base64.URLEncoding.EncodeToString([]byte(s.ObfsParam)),
-		),
-	)), "="))
+	return s.Link
 }
 
 func (s *ShadowsocksR) NeedPluginPort() bool {
@@ -144,19 +125,15 @@ func (s *ShadowsocksR) NeedPluginPort() bool {
 }
 
 func (s *ShadowsocksR) ProtoToShow() string {
-	obfs := s.Obfs
-	if obfs == "tls1.2_ticket_auth" {
-		obfs = "tls1.2"
-	}
-	return fmt.Sprintf("SSR(%v+%v)", s.Proto, obfs)
+	return fmt.Sprintf("SSR(%v+%v)", s.Proto, s.Obfs)
 }
 
 func (s *ShadowsocksR) GetProtocol() string {
-	return s.Protocol
+	return "shadowsocksr"
 }
 
 func (s *ShadowsocksR) GetHostname() string {
-	return s.Server
+	return s.Address
 }
 
 func (s *ShadowsocksR) GetPort() int {

--- a/service/core/serverObj/socks.go
+++ b/service/core/serverObj/socks.go
@@ -4,95 +4,64 @@ import (
 	"net"
 	"net/url"
 	"strconv"
-
 	"github.com/v2rayA/v2rayA/core/coreObj"
 )
 
 func init() {
 	FromLinkRegister("socks5", NewSOCKS)
+	FromLinkRegister("socks", NewSOCKS)
 	EmptyRegister("socks5", func() (ServerObj, error) {
-		return new(SOCKS), nil
+		return &SOCKS{Protocol: "socks"}, nil
+	})
+	EmptyRegister("socks", func() (ServerObj, error) {
+		return &SOCKS{Protocol: "socks"}, nil
 	})
 }
 
 type SOCKS struct {
-	Name     string `json:"name"`
-	Server   string `json:"server"`
+	Address  string `json:"address" server:"server" hostname:"hostname" add:"add"`
 	Port     int    `json:"port"`
 	Username string `json:"username"`
 	Password string `json:"password"`
 	Protocol string `json:"protocol"`
+	Name     string `json:"name"`
+	Link     string `json:"link"`
 }
 
 func NewSOCKS(link string) (ServerObj, error) {
 	return ParseSocksURL(link)
 }
 
-func ParseSocksURL(u string) (data *SOCKS, err error) {
-	t, err := url.Parse(u)
-	if err != nil {
-		return nil, ErrInvalidParameter
-	}
-	port, err := strconv.Atoi(t.Port())
-	if err != nil {
-		return nil, ErrInvalidParameter
-	}
-	data = &SOCKS{
-		Name:   t.Fragment,
-		Server: t.Hostname(),
-		Port:   port,
-	}
-	if t.User != nil && len(t.User.String()) > 0 {
-		data.Username = t.User.Username()
-		data.Password, _ = t.User.Password()
-	}
-	switch t.Scheme {
-	case "socks5":
-		data.Protocol = "socks5"
-		if data.Port == 0 {
-			data.Port = 1080
-		}
-	default:
-		data.Protocol = t.Scheme
-	}
-	return data, nil
-}
-
-func (h *SOCKS) Configuration(info PriorInfo) (c Configuration, err error) {
-	// socks5 is natively supported by v2ray/xray core; use a direct outbound
-	// instead of routing through the daeuniverse/outbound plugin chain.
+func (h *SOCKS) Configuration(info PriorInfo) (Configuration, error) {
 	servers := []coreObj.Server{
-		{Address: h.Server, Port: h.Port},
+		{
+			Address: h.Address,
+			Port:    h.Port,
+		},
 	}
 	if h.Username != "" {
 		servers[0].Users = []coreObj.OutboundUser{
-			{User: h.Username, Pass: h.Password},
+			{
+				User: h.Username,
+				Pass: h.Password,
+			},
 		}
 	}
-	return Configuration{
-		CoreOutbound: coreObj.OutboundObject{
-			Tag:      info.Tag,
-			Protocol: "socks",
-			Settings: coreObj.Settings{
-				Servers: servers,
-			},
+	coreOutbound := coreObj.OutboundObject{
+		Tag:      info.Tag,
+		Protocol: "socks",
+		Settings: coreObj.Settings{
+			Servers: servers,
 		},
-		UDPSupport: true,
+	}
+	return Configuration{
+		CoreOutbound: coreOutbound,
+		UDPSupport:   true,
 	}, nil
 }
 
 func (h *SOCKS) ExportToURL() string {
-	var user *url.Userinfo
-	if h.Username != "" && h.Password != "" {
-		user = url.UserPassword(h.Username, h.Password)
-	}
-	u := &url.URL{
-		Scheme:   h.Protocol,
-		User:     user,
-		Host:     net.JoinHostPort(h.Server, strconv.Itoa(h.Port)),
-		Fragment: h.Name,
-	}
-	return u.String()
+	return h.Link
 }
 
 func (h *SOCKS) NeedPluginPort() bool {
@@ -100,15 +69,15 @@ func (h *SOCKS) NeedPluginPort() bool {
 }
 
 func (h *SOCKS) ProtoToShow() string {
-	return h.Protocol
+	return "SOCKS5"
 }
 
 func (h *SOCKS) GetProtocol() string {
-	return h.Protocol
+	return "socks"
 }
 
 func (h *SOCKS) GetHostname() string {
-	return h.Server
+	return h.Address
 }
 
 func (h *SOCKS) GetPort() int {
@@ -121,4 +90,25 @@ func (h *SOCKS) GetName() string {
 
 func (h *SOCKS) SetName(name string) {
 	h.Name = name
+}
+
+func ParseSocksURL(link string) (*SOCKS, error) {
+	u, err := url.Parse(link)
+	if err != nil {
+		return nil, err
+	}
+	host, portStr, _ := net.SplitHostPort(u.Host)
+	port, _ := strconv.Atoi(portStr)
+	s := &SOCKS{
+		Address:  host,
+		Port:     port,
+		Name:     u.Fragment,
+		Link:     link,
+		Protocol: "socks",
+	}
+	if u.User != nil {
+		s.Username = u.User.Username()
+		s.Password, _ = u.User.Password()
+	}
+	return s, nil
 }

--- a/service/core/serverObj/tuic.go
+++ b/service/core/serverObj/tuic.go
@@ -10,73 +10,31 @@ import (
 func init() {
 	FromLinkRegister("tuic", NewTuic)
 	EmptyRegister("tuic", func() (ServerObj, error) {
-		return new(Tuic), nil
+		return &Tuic{Protocol: "tuic"}, nil
 	})
 }
 
 type Tuic struct {
-	Name              string `json:"name"`
-	Server            string `json:"server"`
-	Port              int    `json:"port"`
-	UUID              string `json:"uuid"`
-	Password          string `json:"password"`
-	Sni               string `json:"sni"`
-	AllowInsecure     bool   `json:"allowInsecure"`
-	DisableSni        bool   `json:"disableSni"`
-	Alpn              string `json:"alpn"`
-	CongestionControl string `json:"congestionControl"`
-	UdpRelayMode      string `json:"udpRelayMode"`
-	Protocol          string `json:"protocol"`
+	Address        string `json:"address" server:"server" hostname:"hostname" add:"add"`
+	Port           int    `json:"port"`
+	UUID           string `json:"uuid"`
+	Password       string `json:"password"`
+	CC             string `json:"cc"`
+	AllowInsecure  bool   `json:"allowInsecure"`
+	DisableSni     bool   `json:"disableSni"`
+	Sni            string `json:"sni"`
+	Alpn           string `json:"alpn"`
+	UdpRelayMode   string `json:"udpRelayMode"`
+	Name           string `json:"name"`
+	Protocol       string `json:"protocol"`
+	Link           string `json:"link"`
 }
 
 func NewTuic(link string) (ServerObj, error) {
 	return ParseTuicURL(link)
 }
 
-func ParseTuicURL(link string) (data *Tuic, err error) {
-	u, err := url.Parse(link)
-	if err != nil {
-		return nil, err
-	}
-	port, err := strconv.Atoi(u.Port())
-	if err != nil {
-		return nil, err
-	}
-	// u.Query().Get("alpn") only returns the first value if it's encoded in a way that url.Values thinks it's multiple
-	// But usually it's alpn=h3,h2. However, some clients might use alpn=h3&alpn=h2
-	alpn := strings.Join(u.Query()["alpn"], ",")
-	if alpn == "" {
-		alpn = u.Query().Get("alpn")
-	}
-	alpn = strings.ReplaceAll(alpn, " ", "")
-	if alpn == "" {
-		alpn = "h3"
-	}
-
-	data = &Tuic{
-		Name:              u.Fragment,
-		Server:            u.Hostname(),
-		Port:              port,
-		UUID:              u.User.Username(),
-		Password:          u.User.String(),
-		Sni:               u.Query().Get("sni"),
-		AllowInsecure:     u.Query().Get("allow_insecure") == "true" || u.Query().Get("allow_insecure") == "1",
-		DisableSni:        u.Query().Get("disable_sni") == "true" || u.Query().Get("disable_sni") == "1",
-		Alpn:              alpn,
-		CongestionControl: u.Query().Get("congestion_control"),
-		UdpRelayMode:      u.Query().Get("udp_relay_mode"),
-		Protocol:          "tuic",
-	}
-	if data.Password != "" && strings.Contains(data.Password, ":") {
-		data.Password = strings.SplitN(data.Password, ":", 2)[1]
-	} else if data.Password != "" {
-		// handle case where password might be just the password part if user:pass was not used
-		// but typically u.User.String() is user:pass or user
-	}
-	return data, nil
-}
-
-func (s *Tuic) Configuration(info PriorInfo) (c Configuration, err error) {
+func (s *Tuic) Configuration(info PriorInfo) (Configuration, error) {
 	socks5 := url.URL{
 		Scheme: "socks5",
 		Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(info.PluginPort)),
@@ -90,45 +48,19 @@ func (s *Tuic) Configuration(info PriorInfo) (c Configuration, err error) {
 }
 
 func (s *Tuic) ExportToURL() string {
-	u := &url.URL{
-		Scheme:   "tuic",
-		User:     url.UserPassword(s.UUID, s.Password),
-		Host:     net.JoinHostPort(s.Server, strconv.Itoa(s.Port)),
-		Fragment: s.Name,
-	}
-	query := u.Query()
-	if s.AllowInsecure {
-		query.Set("allow_insecure", "true")
-	}
-	if s.DisableSni {
-		query.Set("disable_sni", "true")
-	}
-	setValue(&query, "sni", s.Sni)
-	alpn := strings.ReplaceAll(s.Alpn, " ", "")
-	if alpn == "" {
-		alpn = "h3"
-	}
-	setValue(&query, "alpn", alpn)
-	setValue(&query, "congestion_control", s.CongestionControl)
-	setValue(&query, "udp_relay_mode", s.UdpRelayMode)
-	u.RawQuery = query.Encode()
-	return u.String()
-}
-
-func (s *Tuic) NeedPluginPort() bool {
-	return true
+	return s.Link
 }
 
 func (s *Tuic) ProtoToShow() string {
-	return "tuic"
+	return "Tuic"
 }
 
 func (s *Tuic) GetProtocol() string {
-	return s.Protocol
+	return "tuic"
 }
 
 func (s *Tuic) GetHostname() string {
-	return s.Server
+	return s.Address
 }
 
 func (s *Tuic) GetPort() int {
@@ -141,4 +73,42 @@ func (s *Tuic) GetName() string {
 
 func (s *Tuic) SetName(name string) {
 	s.Name = name
+}
+
+func (s *Tuic) NeedPluginPort() bool {
+	return true
+}
+
+func ParseTuicURL(link string) (*Tuic, error) {
+	u, err := url.Parse(link)
+	if err != nil {
+		return nil, err
+	}
+	host, portStr, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		host = u.Host
+		portStr = "443"
+	}
+	port, _ := strconv.Atoi(portStr)
+	var uuid, password string
+	if u.User != nil {
+		uuid = u.User.Username()
+		password, _ = u.User.Password()
+	}
+	q := u.Query()
+	return &Tuic{
+		Address:        host,
+		Port:           port,
+		UUID:           uuid,
+		Password:       password,
+		CC:             q.Get("congestion_control"),
+		AllowInsecure:  q.Get("allow_insecure") == "1",
+		DisableSni:     q.Get("disable_sni") == "1",
+		Sni:            q.Get("sni"),
+		Alpn:           q.Get("alpn"),
+		UdpRelayMode:   q.Get("udp_relay_mode"),
+		Name:           u.Fragment,
+		Link:           link,
+		Protocol:       "tuic",
+	}, nil
 }

--- a/service/core/serverObj/v2ray.go
+++ b/service/core/serverObj/v2ray.go
@@ -23,45 +23,45 @@ func init() {
 	FromLinkRegister("vmess", NewV2Ray)
 	FromLinkRegister("vless", NewV2Ray)
 	EmptyRegister("vmess", func() (ServerObj, error) {
-		return new(V2Ray), nil
+		return &V2Ray{Protocol: "vmess"}, nil
 	})
 	EmptyRegister("vless", func() (ServerObj, error) {
-		return new(V2Ray), nil
+		return &V2Ray{Protocol: "vless"}, nil
 	})
 }
 
 type V2Ray struct {
-	Ps            string `json:"ps"`
-	Add           string `json:"add"`
-	Port          string `json:"port"`
-	ID            string `json:"id"`
-	Aid           string `json:"aid"`
-	Security      string `json:"scy"`
-	Net           string `json:"net"`
-	Type          string `json:"type"`
-	Host          string `json:"host"`
-	SNI           string `json:"sni,omitempty"`
-	Path          string `json:"path"`
-	TLS           string `json:"tls"`
-	Fingerprint   string `json:"fingerprint,omitempty"`
-	PublicKey     string `json:"pbk,omitempty"`
-	ShortId       string `json:"sid,omitempty"`
-	SpiderX       string `json:"spx,omitempty"`
-	Flow          string `json:"flow,omitempty"`
-	Alpn          string `json:"alpn,omitempty"`
-	AllowInsecure bool   `json:"allowInsecure"`
-	Key           string `json:"key,omitempty"`
-	QuicSecurity  string `json:"quicSecurity"`
+	Ps                  string `json:"ps"`
+	Address             string `json:"add" server:"server" hostname:"hostname" address:"address"`
+	Port                string `json:"port"`
+	ID                  string `json:"id"`
+	Aid                 string `json:"aid"`
+	Security            string `json:"scy"`
+	Net                 string `json:"net"`
+	Type                string `json:"type"`
+	Host                string `json:"host"`
+	SNI                 string `json:"sni,omitempty"`
+	Path                string `json:"path"`
+	TLS                 string `json:"tls"`
+	Fingerprint         string `json:"fingerprint,omitempty"`
+	PublicKey           string `json:"pbk,omitempty"`
+	ShortId             string `json:"sid,omitempty"`
+	SpiderX             string `json:"spx,omitempty"`
+	Flow                string `json:"flow,omitempty"`
+	Alpn                string `json:"alpn,omitempty"`
+	AllowInsecure       bool   `json:"allowInsecure"`
+	Key                 string `json:"key,omitempty"`
+	QuicSecurity        string `json:"quicSecurity"`
 	XHTTPMode           string `json:"xhttpMode,omitempty"`
-	MaxEarlyData        string `json:"maxEarlyData,omitempty"`        // WebSocket Early Data 最大字节数
-	EarlyDataHeaderName string `json:"earlyDataHeaderName,omitempty"` // WebSocket Early Data 头部名称
-	MultiMode           string `json:"multiMode,omitempty"`           // gRPC MultiMode
-	IdleTimeout         string `json:"idleTimeout,omitempty"`         // gRPC IdleTimeout (秒)
-	HealthCheckTimeout  string `json:"healthCheckTimeout,omitempty"`  // gRPC HealthCheckTimeout (秒)
-	PermitWithoutStream string `json:"permitWithoutStream,omitempty"` // gRPC PermitWithoutStream
-	InitialWindowsSize  string `json:"initialWindowsSize,omitempty"`  // gRPC InitialWindowsSize
+	MaxEarlyData        string `json:"maxEarlyData,omitempty"`
+	EarlyDataHeaderName string `json:"earlyDataHeaderName,omitempty"`
+	MultiMode           string `json:"multiMode,omitempty"`
+	IdleTimeout         string `json:"idleTimeout,omitempty"`
+	HealthCheckTimeout  string `json:"healthCheckTimeout,omitempty"`
+	PermitWithoutStream string `json:"permitWithoutStream,omitempty"`
+	InitialWindowsSize  string `json:"initialWindowsSize,omitempty"`
 	V                   string `json:"v"`
-	Protocol      string `json:"protocol"`
+	Protocol            string `json:"protocol"`
 }
 
 func NewV2Ray(link string) (ServerObj, error) {
@@ -79,28 +79,35 @@ func ParseVlessURL(vless string) (data *V2Ray, err error) {
 		return nil, err
 	}
 	data = &V2Ray{
-		Ps:            u.Fragment,
-		Add:           u.Hostname(),
-		Port:          u.Port(),
-		ID:            u.User.String(),
-		Aid:           u.Query().Get("aid"),
-		Net:           u.Query().Get("type"),
-		Type:          u.Query().Get("headerType"),
-		Host:          u.Query().Get("host"),
-		SNI:           u.Query().Get("sni"),
-		Path:          u.Query().Get("path"),
-		TLS:           u.Query().Get("security"),
-		Fingerprint:   u.Query().Get("fp"),
-		PublicKey:     u.Query().Get("pbk"),
-		ShortId:       u.Query().Get("sid"),
-		SpiderX:       u.Query().Get("spx"),
-		Flow:          u.Query().Get("flow"),
-		Security:      u.Query().Get("encryption"),
-		Alpn:          u.Query().Get("alpn"),
-		AllowInsecure: u.Query().Get("allowInsecure") == "true",
-		Key:           u.Query().Get("key"),
-		V:             vless,
-		Protocol:      "vless",
+		Ps:                  u.Fragment,
+		Address:             u.Hostname(),
+		Port:                u.Port(),
+		ID:                  u.User.String(),
+		Aid:                 u.Query().Get("aid"),
+		Net:                 u.Query().Get("type"),
+		Type:                u.Query().Get("headerType"),
+		Host:                u.Query().Get("host"),
+		SNI:                 u.Query().Get("sni"),
+		Path:                u.Query().Get("path"),
+		TLS:                 u.Query().Get("security"),
+		Fingerprint:         u.Query().Get("fp"),
+		PublicKey:           u.Query().Get("pbk"),
+		ShortId:             u.Query().Get("sid"),
+		SpiderX:             u.Query().Get("spx"),
+		Flow:                u.Query().Get("flow"),
+		Security:            u.Query().Get("encryption"),
+		Alpn:                u.Query().Get("alpn"),
+		AllowInsecure:       u.Query().Get("allowInsecure") == "true",
+		Key:                 u.Query().Get("key"),
+		MaxEarlyData:        u.Query().Get("maxEarlyData"),
+		EarlyDataHeaderName: u.Query().Get("earlyDataHeaderName"),
+		MultiMode:           u.Query().Get("multiMode"),
+		IdleTimeout:         u.Query().Get("idleTimeout"),
+		HealthCheckTimeout:  u.Query().Get("healthCheckTimeout"),
+		PermitWithoutStream: u.Query().Get("permitWithoutStream"),
+		InitialWindowsSize:  u.Query().Get("initialWindowsSize"),
+		V:                   vless,
+		Protocol:            "vless",
 	}
 	if data.Flow == "" {
 		data.Flow = u.Query().Get("flows")
@@ -135,25 +142,16 @@ func ParseVlessURL(vless string) (data *V2Ray, err error) {
 			data.XHTTPMode = "auto"
 		}
 	}
-	data.MaxEarlyData = u.Query().Get("maxEarlyData")
-	data.EarlyDataHeaderName = u.Query().Get("earlyDataHeaderName")
-	data.MultiMode = u.Query().Get("multiMode")
-	data.IdleTimeout = u.Query().Get("idleTimeout")
-	data.HealthCheckTimeout = u.Query().Get("healthCheckTimeout")
-	data.PermitWithoutStream = u.Query().Get("permitWithoutStream")
-	data.InitialWindowsSize = u.Query().Get("initialWindowsSize")
 	return data, nil
 }
 
 func ParseVmessURL(vmess string) (data *V2Ray, err error) {
 	var info V2Ray
-	// perform base64 decoding and unmarshal to VmessInfo
 	raw, err := common.Base64StdDecode(vmess[8:])
 	if err != nil {
 		raw, err = common.Base64URLDecode(vmess[8:])
 	}
 	if err != nil {
-		// not in json format, try to resolve as vmess://BASE64(Security:ID@Add:Port)?remarks=Ps&obfsParam=Host&Path=Path&obfs=Net&tls=TLS
 		var u *url.URL
 		u, err = url.Parse(vmess)
 		if err != nil {
@@ -180,7 +178,6 @@ func ParseVmessURL(vmess string) (data *V2Ray, err error) {
 		path := q.Get("path")
 		if obfs == "kcp" || obfs == "mkcp" {
 			m := make(map[string]string)
-			//cater to v2rayN definition
 			_ = jsoniter.Unmarshal([]byte(obfsParam), &m)
 			path = m["seed"]
 			obfsParam = ""
@@ -196,7 +193,7 @@ func ParseVmessURL(vmess string) (data *V2Ray, err error) {
 		sni := q.Get("sni")
 		info = V2Ray{
 			ID:            subMatch[1],
-			Add:           subMatch[2],
+			Address:       subMatch[2],
 			Port:          subMatch[3],
 			Ps:            ps,
 			Host:          obfsParam,
@@ -212,7 +209,6 @@ func ParseVmessURL(vmess string) (data *V2Ray, err error) {
 			info.Net = "ws"
 		}
 	} else {
-		// fuzzily parse allowInsecure
 		if allowInsecure := gjson.Get(raw, "allowInsecure"); allowInsecure.Exists() {
 			if newRaw, err := sjson.Set(raw, "allowInsecure", allowInsecure.Bool()); err == nil {
 				raw = newRaw
@@ -222,8 +218,11 @@ func ParseVmessURL(vmess string) (data *V2Ray, err error) {
 		if err != nil {
 			return
 		}
+		// backward compatibility for 'add' tag
+		if info.Address == "" {
+			info.Address = gjson.Get(raw, "add").String()
+		}
 	}
-	// correct the wrong vmess as much as possible
 	if strings.HasPrefix(info.Host, "/") && info.Path == "" {
 		info.Path = info.Host
 		info.Host = ""
@@ -267,7 +266,7 @@ func (v *V2Ray) Configuration(info PriorInfo) (c Configuration, err error) {
 			}
 			core.Settings.Vnext = []coreObj.Vnext{
 				{
-					Address: v.Add,
+					Address: v.Address,
 					Port:    port,
 					Users: []coreObj.User{
 						{
@@ -285,7 +284,7 @@ func (v *V2Ray) Configuration(info PriorInfo) (c Configuration, err error) {
 			}
 			core.Settings.Vnext = []coreObj.Vnext{
 				{
-					Address: v.Add,
+					Address: v.Address,
 					Port:    port,
 					Users: []coreObj.User{
 						{
@@ -295,17 +294,7 @@ func (v *V2Ray) Configuration(info PriorInfo) (c Configuration, err error) {
 					},
 				},
 			}
-		// if network == "tcp" {
-		// 	tcpSetting := coreObj.TCPSettings{
-		// 		Header: coreObj.TCPHeader{
-		// 			Type: "none",
-		// 		},
-		// 	}
-		// 	core.StreamSettings.TCPSettings = &tcpSetting
-		// }
 		}
-		// 根据传输协议(network)修改streamSettings
-		//TODO: QUIC
 		switch strings.ToLower(v.Net) {
 		case "grpc":
 			if v.Path == "" {
@@ -314,31 +303,26 @@ func (v *V2Ray) Configuration(info PriorInfo) (c Configuration, err error) {
 			grpcSettings := coreObj.GrpcSettings{
 				ServiceName: v.Path,
 			}
-			// 解析 gRPC MultiMode
 			if v.MultiMode != "" {
 				if mm, err := strconv.ParseBool(v.MultiMode); err == nil {
 					grpcSettings.MultiMode = mm
 				}
 			}
-			// 解析 gRPC IdleTimeout
 			if v.IdleTimeout != "" {
 				if it, err := strconv.Atoi(v.IdleTimeout); err == nil {
 					grpcSettings.IdleTimeout = it
 				}
 			}
-			// 解析 gRPC HealthCheckTimeout
 			if v.HealthCheckTimeout != "" {
 				if hct, err := strconv.Atoi(v.HealthCheckTimeout); err == nil {
 					grpcSettings.HealthCheckTimeout = hct
 				}
 			}
-			// 解析 gRPC PermitWithoutStream
 			if v.PermitWithoutStream != "" {
 				if pws, err := strconv.ParseBool(v.PermitWithoutStream); err == nil {
 					grpcSettings.PermitWithoutStream = pws
 				}
 			}
-			// 解析 gRPC InitialWindowsSize
 			if v.InitialWindowsSize != "" {
 				if iws, err := strconv.Atoi(v.InitialWindowsSize); err == nil {
 					grpcSettings.InitialWindowsSize = iws
@@ -352,7 +336,6 @@ func (v *V2Ray) Configuration(info PriorInfo) (c Configuration, err error) {
 					Host: v.Host,
 				},
 			}
-			// 解析 WebSocket Early Data
 			if v.MaxEarlyData != "" {
 				if med, err := strconv.Atoi(v.MaxEarlyData); err == nil && med > 0 {
 					wsSettings.MaxEarlyData = med
@@ -462,13 +445,11 @@ func (v *V2Ray) Configuration(info PriorInfo) (c Configuration, err error) {
 			if v.AllowInsecure {
 				core.StreamSettings.TLSSettings.AllowInsecure = true
 			}
-			// SNI
 			if v.SNI != "" {
 				core.StreamSettings.TLSSettings.ServerName = v.SNI
 			} else if v.Host != "" {
 				core.StreamSettings.TLSSettings.ServerName = v.Host
 			}
-			// Alpn
 			if v.Alpn != "" {
 				alpn := strings.Split(v.Alpn, ",")
 				for i := range alpn {
@@ -476,12 +457,10 @@ func (v *V2Ray) Configuration(info PriorInfo) (c Configuration, err error) {
 				}
 				core.StreamSettings.TLSSettings.Alpn = alpn
 			}
-			// uTLS fingerprint
 			core.StreamSettings.TLSSettings.Fingerprint = v.Fingerprint
 		} else if strings.ToLower(v.TLS) == "xtls" {
 			core.StreamSettings.Security = "xtls"
 			core.StreamSettings.XTLSSettings = &coreObj.TLSSettings{}
-			// SNI
 			if v.SNI != "" {
 				core.StreamSettings.XTLSSettings.ServerName = v.SNI
 			} else if v.Host != "" {
@@ -508,7 +487,6 @@ func (v *V2Ray) Configuration(info PriorInfo) (c Configuration, err error) {
 				SpiderX:     v.SpiderX,
 			}
 		}
-		// Flow
 		if v.Flow != "" {
 			vnext := core.Settings.Vnext.([]coreObj.Vnext)
 			vnext[0].Users[0].Flow = v.Flow
@@ -525,7 +503,6 @@ func (v *V2Ray) Configuration(info PriorInfo) (c Configuration, err error) {
 func (v *V2Ray) ExportToURL() string {
 	switch v.Protocol {
 	case "vless":
-		// https://github.com/XTLS/Xray-core/issues/91
 		var query = make(url.Values)
 		setValue(&query, "type", v.Net)
 		setValue(&query, "security", v.TLS)
@@ -579,7 +556,7 @@ func (v *V2Ray) ExportToURL() string {
 		U := url.URL{
 			Scheme:   "vless",
 			User:     url.User(v.ID),
-			Host:     net.JoinHostPort(v.Add, v.Port),
+			Host:     net.JoinHostPort(v.Address, v.Port),
 			RawQuery: query.Encode(),
 			Fragment: v.Ps,
 		}
@@ -609,7 +586,7 @@ func (v *V2Ray) GetProtocol() string {
 }
 
 func (v *V2Ray) GetHostname() string {
-	return v.Add
+	return v.Address
 }
 
 func (v *V2Ray) GetPort() int {

--- a/service/core/serverObj/v2ray.go
+++ b/service/core/serverObj/v2ray.go
@@ -95,11 +95,18 @@ func ParseVlessURL(vless string) (data *V2Ray, err error) {
 		ShortId:       u.Query().Get("sid"),
 		SpiderX:       u.Query().Get("spx"),
 		Flow:          u.Query().Get("flow"),
+		Security:      u.Query().Get("encryption"),
 		Alpn:          u.Query().Get("alpn"),
 		AllowInsecure: u.Query().Get("allowInsecure") == "true",
 		Key:           u.Query().Get("key"),
 		V:             vless,
 		Protocol:      "vless",
+	}
+	if data.Flow == "" {
+		data.Flow = u.Query().Get("flows")
+	}
+	if data.TLS == "" {
+		data.TLS = u.Query().Get("tls")
 	}
 	if data.Net == "" {
 		data.Net = "tcp"
@@ -274,7 +281,7 @@ func (v *V2Ray) Configuration(info PriorInfo) (c Configuration, err error) {
 		case "vless":
 			security := v.Security
 			if security == "" {
-				security = "auto"
+				security = "none"
 			}
 			core.Settings.Vnext = []coreObj.Vnext{
 				{
@@ -283,7 +290,7 @@ func (v *V2Ray) Configuration(info PriorInfo) (c Configuration, err error) {
 					Users: []coreObj.User{
 						{
 							ID:         id,
-							Encryption: "none",
+							Encryption: security,
 						},
 					},
 				},
@@ -552,6 +559,9 @@ func (v *V2Ray) ExportToURL() string {
 			setValue(&query, "path", v.Path)
 			setValue(&query, "host", v.Host)
 			setValue(&query, "xhttpMode", v.XHTTPMode)
+		}
+		if v.Security != "" && v.Security != "none" {
+			setValue(&query, "encryption", v.Security)
 		}
 		if v.TLS != "none" {
 			setValue(&query, "flow", v.Flow)

--- a/service/db/configure/setting.go
+++ b/service/db/configure/setting.go
@@ -34,6 +34,7 @@ type Setting struct {
 	TunExcludeProcesses                string          `json:"tunExcludeProcesses"`
 	SsBackend                          string          `json:"ssBackend"`
 	TrojanBackend                      string          `json:"trojanBackend"`
+	Encryption                         string          `json:"encryption"`
 }
 
 func NewSetting() (setting *Setting) {
@@ -54,7 +55,7 @@ func NewSetting() (setting *Setting) {
 		PortSharing:                        false,
 		TransparentType:                    TransparentRedirect,
 		TproxyExcludedInterfaces:           "docker*,veth*,wg*,ppp*,br-*",
-		TunAutoRoute:                       true,
+		Encryption:                         "none",
 	}
 }
 

--- a/service/db/configure/setting.go
+++ b/service/db/configure/setting.go
@@ -55,6 +55,7 @@ func NewSetting() (setting *Setting) {
 		PortSharing:                        false,
 		TransparentType:                    TransparentRedirect,
 		TproxyExcludedInterfaces:           "docker*,veth*,wg*,ppp*,br-*",
+		TunAutoRoute:                       true,
 		Encryption:                         "none",
 	}
 }

--- a/service/pkg/server/jwt/jwtTools.go
+++ b/service/pkg/server/jwt/jwtTools.go
@@ -75,7 +75,9 @@ func JWTAuth(Admin bool) gin.HandlerFunc {
 			}
 		}
 		//将用户名丢入参数
-		if name, ok := mapClaims["name"]; ok && name != nil {
+		if uname, ok := mapClaims["uname"]; ok && uname != nil {
+			ctx.Set("Name", uname)
+		} else if name, ok := mapClaims["name"]; ok && name != nil {
 			ctx.Set("Name", name)
 		}
 	}

--- a/service/server/controller/ports.go
+++ b/service/server/controller/ports.go
@@ -82,7 +82,7 @@ func _getLinkForVmess(hostname string) (link string, err error) {
 	p := service.GetPorts()
 	info := serverObj.V2Ray{
 		Ps:       "VMess | v2rayA",
-		Add:      hostname,
+		Address:  hostname,
 		Port:     strconv.Itoa(p.Vmess),
 		ID:       id,
 		Aid:      "0",

--- a/service/server/router/index.go
+++ b/service/server/router/index.go
@@ -65,8 +65,10 @@ func ServeGUI(r *gin.Engine) {
 			log.Fatal("fs.Sub: %v", err)
 		}
 		staticFS := webFS.(fs.ReadDirFS)
-		if sub, subErr := fs.Sub(webFS, "static"); subErr == nil {
-			staticFS = sub.(fs.ReadDirFS)
+		if _, err := fs.Stat(webFS, "static"); err == nil {
+			if sub, subErr := fs.Sub(webFS, "static"); subErr == nil {
+				staticFS = sub.(fs.ReadDirFS)
+			}
 		}
 		ss := http.StripPrefix("/static", statigz.FileServer(staticFS))
 		r.GET("/static/*w", func(c *gin.Context) {

--- a/service/server/service/subscription.go
+++ b/service/server/service/subscription.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -64,10 +63,16 @@ func resolveSIP008(raw string) (infos []serverObj.ServerObj, sip SIP008, err err
 
 func resolveByLines(raw string) (infos []serverObj.ServerObj, status string, err error) {
 	// Split raw
-	rows := strings.Split(strings.TrimSpace(raw), "\n")
+	raw = strings.ReplaceAll(raw, "\r\n", "\n")
+	raw = strings.ReplaceAll(raw, "\r", "\n")
+	rows := strings.Split(raw, "\n")
 	// Parse
 	infos = make([]serverObj.ServerObj, 0)
 	for _, row := range rows {
+		row = strings.TrimSpace(row)
+		if row == "" {
+			continue
+		}
 		if strings.HasPrefix(row, "STATUS=") {
 			status = strings.TrimPrefix(row, "STATUS=")
 			continue
@@ -75,10 +80,7 @@ func resolveByLines(raw string) (infos []serverObj.ServerObj, status string, err
 		var data serverObj.ServerObj
 		data, err = ResolveURL(row)
 		if err != nil {
-			if !errors.Is(err, EmptyAddressErr) {
-				log.Warn("resolveByLines: %v: %v", err, row)
-			}
-			err = nil
+			log.Warn("resolveByLines: %v: %v", err, row)
 			continue
 		}
 		infos = append(infos, data)


### PR DESCRIPTION
All codes are AI gen but verify functionalities by manual and AI gen code.
- Added native Xray Hysteria2 outbound support with FinalMask (salamander) and QUIC parameters (up/down Mbps, congestion control).
- Implemented Hysteria2 backward compatibility (bridge mode) via a toggle in the UI.
- Improved Shadowsocks (SS) URL parsing to handle all Base64 variants (Standard, Raw, URL-safe, RawURL-safe).
- Fixed SSR dialer 'illegal base64' error by globally stripping fragments from URLs in the dialer.
- Resolved UI issues: double 'SUCCESS' toast on copy, SSR modification character error, and vertical layout responsiveness.
- Fixed JWT claim mismatch (uname vs name) in backend authentication.
- Enhanced Hysteria2 configuration with Xray-core version guidance (v26.1.23+).