### PR TITLE
Feature/auto change

### DIFF
--- a/service/core/v2ray/asset/asset.go
+++ b/service/core/v2ray/asset/asset.go
@@ -83,6 +83,7 @@ func GetV2rayLocationAsset(filename string) (string, error) {
 			// symlink all assets into XDG_RUNTIME_DIR
 			relpath := filepath.Join(folder, filename)
 			fullpath, err := xdg.SearchDataFile(relpath)
+			log.Info("V2RAY_LOCATION_ASSET: %v", fullpath)
 			if err != nil {
 				fullpath, err = xdg.DataFile(relpath)
 				if err != nil {

--- a/service/core/v2ray/asset/dat/geoip.go
+++ b/service/core/v2ray/asset/dat/geoip.go
@@ -2,10 +2,11 @@ package dat
 
 import (
 	"fmt"
-	"github.com/v2rayA/v2rayA/core/v2ray/asset"
-	"github.com/v2rayA/v2rayA/pkg/util/log"
 	"os"
 	"strings"
+
+	"github.com/v2rayA/v2rayA/core/v2ray/asset"
+	"github.com/v2rayA/v2rayA/pkg/util/log"
 )
 
 func UpdateLocalGeoIP() (err error) {
@@ -13,11 +14,11 @@ func UpdateLocalGeoIP() (err error) {
 	if err != nil {
 		return err
 	}
-	if err = asset.Download("https://github.com/v2fly/geoip/releases/latest/download/geoip.dat", pathSiteDat+".new"); err != nil {
+	if err = asset.Download("https://ghp.ci/https://github.com/v2fly/geoip/releases/latest/download/geoip.dat", pathSiteDat+".new"); err != nil {
 		log.Warn("UpdateLocalGeoIP: %v", err)
 		return
 	}
-	siteDatSha256, err := httpGet("https://github.com/v2fly/geoip/releases/latest/download/geoip.dat.sha256sum")
+	siteDatSha256, err := httpGet("https://ghp.ci/https://github.com/v2fly/geoip/releases/latest/download/geoip.dat.sha256sum")
 	if err != nil {
 		err = fmt.Errorf("%w: %v", FailCheckSha, err)
 		log.Warn("UpdateLocalGeoIP: %v", err)

--- a/service/core/v2ray/asset/dat/geosite.go
+++ b/service/core/v2ray/asset/dat/geosite.go
@@ -2,10 +2,11 @@ package dat
 
 import (
 	"fmt"
-	"github.com/v2rayA/v2rayA/core/v2ray/asset"
-	"github.com/v2rayA/v2rayA/pkg/util/log"
 	"os"
 	"strings"
+
+	"github.com/v2rayA/v2rayA/core/v2ray/asset"
+	"github.com/v2rayA/v2rayA/pkg/util/log"
 )
 
 func UpdateLocalGeoSite() (err error) {
@@ -14,11 +15,11 @@ func UpdateLocalGeoSite() (err error) {
 		return err
 	}
 
-	if err = asset.Download("https://github.com/v2fly/domain-list-community/releases/latest/download/dlc.dat", pathSiteDat+".new"); err != nil {
+	if err = asset.Download("https://ghp.ci/https://github.com/v2fly/domain-list-community/releases/latest/download/dlc.dat", pathSiteDat+".new"); err != nil {
 		log.Warn("UpdateLocalGeoSite: %v", err)
 		return
 	}
-	siteDatSha256, err := httpGet("https://github.com/v2fly/domain-list-community/releases/latest/download/dlc.dat.sha256sum")
+	siteDatSha256, err := httpGet("https://ghp.ci/https://github.com/v2fly/domain-list-community/releases/latest/download/dlc.dat.sha256sum")
 	if err != nil {
 		err = fmt.Errorf("%w: %v", FailCheckSha, err)
 		log.Warn("UpdateLocalGeoSite: %v", err)

--- a/service/core/v2ray/asset/dat/gfwlist.go
+++ b/service/core/v2ray/asset/dat/gfwlist.go
@@ -108,12 +108,12 @@ func UpdateLocalGFWList() (localGFWListVersionAfterUpdate string, err error) {
 	if err != nil {
 		return "", err
 	}
-	u := fmt.Sprintf(`https://github.com/v2rayA/dist-v2ray-rules-dat/raw/%v/geosite.dat`, gfwlist.Tag)
+	u := fmt.Sprintf(`https://ghp.ci/https://github.com/v2rayA/dist-v2ray-rules-dat/raw/%v/geosite.dat`, gfwlist.Tag)
 	if err = asset.Download(u, pathSiteDat+".new"); err != nil {
 		log.Warn("UpdateLocalGFWList: %v", err)
 		return
 	}
-	u2 := fmt.Sprintf(`https://github.com/v2rayA/dist-v2ray-rules-dat/raw/%v/geosite.dat.sha256sum`, gfwlist.Tag)
+	u2 := fmt.Sprintf(`https://ghp.ci/https://github.com/v2rayA/dist-v2ray-rules-dat/raw/%v/geosite.dat.sha256sum`, gfwlist.Tag)
 	siteDatSha256, err := httpGet(u2)
 	if err != nil {
 		err = fmt.Errorf("%w: %v", FailCheckSha, err)

--- a/service/pre.go
+++ b/service/pre.go
@@ -171,37 +171,40 @@ func initConfigure() {
 
 	//首先确定v2ray是否存在
 	if _, err := where.GetV2rayBinPath(); err == nil {
-		//检查geoip、geosite是否存在
-		if !asset.DoesV2rayAssetExist("geoip.dat") || !asset.DoesV2rayAssetExist("geosite.dat") {
-			log.Alert("downloading missing geoip.dat and geosite.dat")
-			var l net.Listener
-			if l, err = net.Listen("tcp", conf.GetEnvironmentConfig().Address); err != nil {
-				log.Fatal("net.Listen: %v", err)
-			}
-			e := gin.New()
-			e.GET("/", func(c *gin.Context) {
-				c.Header("Cache-Control", "no-cache, no-store, max-age=0, must-revalidate")
-				c.Header("Pragma", "no-cache")
-				c.Header("Expires", "0")
-				c.String(200, "Downloading missing geoip.dat and geosite.dat; refresh the page later.\n正在下载缺失的 geoip.dat 和 geosite.dat，请稍后刷新页面。")
-			})
-			go e.RunListener(l)
-			if !asset.DoesV2rayAssetExist("geoip.dat") {
-				err := dat.UpdateLocalGeoIP()
-				if err != nil {
-					log.Fatal("UpdateLocalGeoIP: %v", err)
+
+		if true {
+			//检查geoip、geosite是否存在
+			if !asset.DoesV2rayAssetExist("geoip.dat") || !asset.DoesV2rayAssetExist("geosite.dat") {
+				log.Alert("downloading missing geoip.dat and geosite.dat")
+				var l net.Listener
+				if l, err = net.Listen("tcp", conf.GetEnvironmentConfig().Address); err != nil {
+					log.Fatal("net.Listen: %v", err)
 				}
-			}
-			if !asset.DoesV2rayAssetExist("geosite.dat") {
-				err = dat.UpdateLocalGeoSite()
-				if err != nil {
-					log.Fatal("UpdateLocalGeoSite: %v", err)
+				e := gin.New()
+				e.GET("/", func(c *gin.Context) {
+					c.Header("Cache-Control", "no-cache, no-store, max-age=0, must-revalidate")
+					c.Header("Pragma", "no-cache")
+					c.Header("Expires", "0")
+					c.String(200, "Downloading missing geoip.dat and geosite.dat; refresh the page later.\n正在下载缺失的 geoip.dat 和 geosite.dat，请稍后刷新页面。")
+				})
+				go e.RunListener(l)
+				if !asset.DoesV2rayAssetExist("geoip.dat") {
+					err := dat.UpdateLocalGeoIP()
+					if err != nil {
+						log.Fatal("UpdateLocalGeoIP: %v", err)
+					}
 				}
+				if !asset.DoesV2rayAssetExist("geosite.dat") {
+					err = dat.UpdateLocalGeoSite()
+					if err != nil {
+						log.Fatal("UpdateLocalGeoSite: %v", err)
+					}
+				}
+				if l != nil {
+					l.Close()
+				}
+				log.Alert("geoip.dat and geosite.dat are ready")
 			}
-			if l != nil {
-				l.Close()
-			}
-			log.Alert("geoip.dat and geosite.dat are ready")
 		}
 	}
 }

--- a/service/pre.go
+++ b/service/pre.go
@@ -345,6 +345,7 @@ func run() (err error) {
 	go func() {
 		errch <- router.Run()
 	}()
+	service.StartAutoSwitchTicker()
 	//监听信号，处理透明代理的关闭
 	go func() {
 		sigs := make(chan os.Signal, 1)

--- a/service/server/service/auto_switch.go
+++ b/service/server/service/auto_switch.go
@@ -1,0 +1,199 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/v2rayA/v2rayA/common/httpClient"
+	"github.com/v2rayA/v2rayA/core/v2ray"
+	"github.com/v2rayA/v2rayA/db/configure"
+	"github.com/v2rayA/v2rayA/pkg/util/log"
+)
+
+const (
+	autoSwitchInterval        = 5 * time.Minute
+	autoSwitchConfirmInterval = 5 * time.Second
+	autoSwitchProbeTimeout    = 8 * time.Second
+	autoSwitchTestURL         = "https://chatgpt.com/"
+)
+
+var autoSwitchMu sync.Mutex
+
+func StartAutoSwitchTicker() {
+	go func() {
+		timer := time.NewTimer(autoSwitchInterval)
+		defer timer.Stop()
+		for range timer.C {
+			AutoSwitchOnce()
+			timer.Reset(autoSwitchInterval)
+		}
+	}()
+}
+
+func AutoSwitchOnce() {
+	if !autoSwitchMu.TryLock() {
+		return
+	}
+	defer autoSwitchMu.Unlock()
+
+	if !v2ray.ProcessManager.Running() || configure.GetConnectedServers() == nil {
+		return
+	}
+	if currentProxyReachable() {
+		return
+	}
+	log.Warn("[AutoSwitch] current proxy cannot reach %s, confirming twice", autoSwitchTestURL)
+	for i := 0; i < 2; i++ {
+		time.Sleep(autoSwitchConfirmInterval)
+		if currentProxyReachable() {
+			log.Info("[AutoSwitch] current proxy recovered")
+			return
+		}
+	}
+	if err := switchToReachableServer(); err != nil {
+		log.Warn("[AutoSwitch] %v", err)
+	}
+}
+
+func currentProxyReachable() bool {
+	c, err := httpClient.GetHttpClientWithv2rayAProxy()
+	if err != nil {
+		log.Debug("[AutoSwitch] GetHttpClientWithv2rayAProxy: %v", err)
+		return false
+	}
+	defer c.CloseIdleConnections()
+	c.Timeout = autoSwitchProbeTimeout
+	c.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 5 {
+			return http.ErrUseLastResponse
+		}
+		return nil
+	}
+	req, err := http.NewRequest(http.MethodGet, autoSwitchTestURL, nil)
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Accept", "*/*")
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("Connection", "close")
+	req.Header.Set("User-Agent", "curl/7.70.0")
+	resp, err := c.Do(req)
+	if err != nil {
+		log.Debug("[AutoSwitch] probe failed: %v", err)
+		return false
+	}
+	_ = resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 500
+}
+
+func switchToReachableServer() error {
+	connected := configure.GetConnectedServers()
+	if connected == nil || connected.Len() == 0 {
+		return nil
+	}
+	outbound := connected.Get()[0].Outbound
+	if outbound == "" {
+		outbound = "proxy"
+	}
+	backup := configure.GetConnectedServersByOutbound(outbound)
+	candidates := allServerWhiches(outbound)
+	if len(candidates) == 0 {
+		return fmt.Errorf("no candidate servers")
+	}
+
+	log.Info("[AutoSwitch] testing %d candidate servers", len(candidates))
+	tested, err := TestHttpLatency(candidates, autoSwitchProbeTimeout, 16, false, "")
+	if err != nil {
+		return fmt.Errorf("test candidate servers: %w", err)
+	}
+	for _, candidate := range tested {
+		if !latencyAvailable(candidate.Latency) {
+			continue
+		}
+		isCurrent := false
+		if backup != nil {
+			for _, old := range backup.Get() {
+				if old.EqualTo(*candidate) {
+					isCurrent = true
+					break
+				}
+			}
+		}
+		if isCurrent {
+			continue
+		}
+		log.Info("[AutoSwitch] trying server: type=%s sub=%d id=%d outbound=%s latency=%s", candidate.TYPE, candidate.Sub, candidate.ID, outbound, candidate.Latency)
+		if err := replaceOutbound(outbound, candidate, backup); err != nil {
+			log.Warn("[AutoSwitch] switch failed: %v", err)
+			continue
+		}
+		time.Sleep(autoSwitchConfirmInterval)
+		if currentProxyReachable() {
+			log.Info("[AutoSwitch] switched to server: type=%s sub=%d id=%d outbound=%s", candidate.TYPE, candidate.Sub, candidate.ID, outbound)
+			return nil
+		}
+		log.Warn("[AutoSwitch] switched server cannot reach %s, trying next", autoSwitchTestURL)
+	}
+	if backup != nil {
+		_ = configure.OverwriteConnects(backup)
+		_ = v2ray.UpdateV2RayConfig()
+	}
+	return fmt.Errorf("no reachable candidate server found")
+}
+
+func allServerWhiches(outbound string) []*configure.Which {
+	var whiches []*configure.Which
+	servers := configure.GetServers()
+	for i := range servers {
+		whiches = append(whiches, &configure.Which{
+			TYPE:     configure.ServerType,
+			ID:       i + 1,
+			Outbound: outbound,
+		})
+	}
+	subscriptions := configure.GetSubscriptions()
+	for sub := range subscriptions {
+		for i := range subscriptions[sub].Servers {
+			whiches = append(whiches, &configure.Which{
+				TYPE:     configure.SubscriptionServerType,
+				ID:       i + 1,
+				Sub:      sub,
+				Outbound: outbound,
+			})
+		}
+	}
+	return whiches
+}
+
+func latencyAvailable(latency string) bool {
+	return strings.HasSuffix(latency, "ms")
+}
+
+func replaceOutbound(outbound string, which *configure.Which, backup *configure.Whiches) (err error) {
+	if outbound == "" {
+		outbound = "proxy"
+	}
+	which.Outbound = outbound
+	defer func() {
+		if err != nil && backup != nil && v2ray.ProcessManager.Running() {
+			_ = configure.OverwriteConnects(backup)
+			_ = v2ray.UpdateV2RayConfig()
+		}
+	}()
+	if err = configure.ClearConnects(outbound); err != nil {
+		return err
+	}
+	if err = checkSupport([]*configure.Which{which}); err != nil {
+		return err
+	}
+	if err = configure.AddConnect(*which); err != nil {
+		return err
+	}
+	if v2ray.ProcessManager.Running() {
+		return v2ray.UpdateV2RayConfig()
+	}
+	return nil
+}


### PR DESCRIPTION
  - 每 5 分钟后台检测一次当前 v2rayA SOCKS 代理是否可达 https://chatgpt.com/。
  - 如果当前可达，不切换。
  - 如果失败，等待 5 秒复测，再等待 5 秒复测。
  - 仍失败后，枚举所有本地节点和订阅节点，复用现有 TestHttpLatency 找可用候选。
  - 切换到候选节点后，再通过当前代理验证 https://chatgpt.com/。
  - 验证失败就继续尝试下一个候选；全部失败则恢复原来的 outbound 选择。