### PR TITLE
fix(db/sqlite): fix empty subscription servers due to invalid JSON marshal

### DIFF
--- a/service/db/listOp.go
+++ b/service/db/listOp.go
@@ -3,6 +3,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/tidwall/gjson"
@@ -114,18 +115,18 @@ func ListGet(bucket string, key string, index int) (b []byte, err error) {
 		}
 		defer rows.Close()
 
-		var servers []gjson.Result
+		var servers []string
 		for rows.Next() {
 			var s string
 			if err := rows.Scan(&s); err != nil {
 				return nil, err
 			}
-			servers = append(servers, gjson.Parse(s))
+			servers = append(servers, s)
 		}
 
-		serversJSON, _ := jsoniter.Marshal(servers)
+		serversJSON := "[" + strings.Join(servers, ",") + "]"
 		result := fmt.Sprintf(`{"address":"%s","status":"%s","info":"%s","servers":%s}`,
-			address, status, info, string(serversJSON))
+			address, status, info, serversJSON)
 		return []byte(result), nil
 
 	default:
@@ -265,20 +266,20 @@ func ListGetAll(bucket string, key string) (list [][]byte, err error) {
 				return nil, err
 			}
 
-			var servers []gjson.Result
+			var servers []string
 			for serverRows.Next() {
 				var s string
 				if err := serverRows.Scan(&s); err != nil {
 					serverRows.Close()
 					return nil, err
 				}
-				servers = append(servers, gjson.Parse(s))
+				servers = append(servers, s)
 			}
 			serverRows.Close()
 
-			serversJSON, _ := jsoniter.Marshal(servers)
+			serversJSON := "[" + strings.Join(servers, ",") + "]"
 			result := fmt.Sprintf(`{"address":"%s","status":"%s","info":"%s","servers":%s}`,
-				address, status, info, string(serversJSON))
+				address, status, info, serversJSON)
 			list = append(list, []byte(result))
 		}
 		return list, rows.Err()


### PR DESCRIPTION
### Description
Fixes an issue where importing subscriptions in v2rayA with SQLite backend results in an empty server list due to broken JSON structure after marshaling `[]gjson.Result`.

### Changes
- Changed temporary slice type from `[]gjson.Result` to `[]string` in both `ListGet` and `ListGetAll` for `touch/subscriptions`.
- Used `strings.Join` to manually build the JSON array, restoring the original valid format.

### Verification
- Code has been manually reviewed and logic verified.
- Re-established the same output format as legacy BoltDB implementation.