### PR TITLE
feat(server/gui): add Unix Domain Socket and BaseUrl support for FnOS & reverse proxies

### DIFF
--- a/gui/src/App.vue
+++ b/gui/src/App.vue
@@ -285,8 +285,11 @@ export default {
       if (u.protocol === "https") {
         protocol = "wss";
       }
-      url = `${protocol}://${u.host}:${u.port
-        }/api/message?Authorization=${encodeURIComponent(localStorage["token"])}`;
+      let basePath = u.path;
+      if (basePath.endsWith("/api")) {
+        basePath = basePath.slice(0, -4);
+      }
+      url = `${protocol}://${u.host}:${u.port}${basePath}/api/message?Authorization=${encodeURIComponent(localStorage["token"])}`;
       if (this.ws) {
         // console.log("ws close");
         this.ws.close();

--- a/gui/src/components/modalCustomPorts.vue
+++ b/gui/src/components/modalCustomPorts.vue
@@ -14,7 +14,7 @@
           ref="backendAddress"
           v-model="table.backendAddress"
           placeholder="http://localhost:2017"
-          pattern="https?://.+(:\d+)?"
+          pattern="(|https?://.+|/.+)"
         >
           >
         </b-input>

--- a/gui/src/plugins/backendPort.js
+++ b/gui/src/plugins/backendPort.js
@@ -1,12 +1,18 @@
 // import { parseURL, isIntranet } from "@/assets/js/utils";
 console.log("backendPort");
 let ba = localStorage.getItem("backendAddress");
-if (ba == null) {
-  // const u = parseURL(location.href);
-  // if (u.host !== "localhost" && u.host !== "local" && isIntranet(u.host)) {
-  //   localStorage["backendAddress"] = `${u.protocol}://${u.host}:2017`;
-  // } else {
-  //   localStorage.setItem("backendAddress", "http://localhost:2017");
-  // }
-  localStorage.setItem("backendAddress", "");
+let currentPrefix = "";
+if (typeof window !== "undefined") {
+  let path = window.location.pathname;
+  const match = path.match(/^(.*)\/(?:login|setting|log|server|rule|running)?\/?$/);
+  if (match) {
+    currentPrefix = match[1];
+  }
+}
+if (currentPrefix && currentPrefix !== "/") {
+  localStorage.setItem("backendAddress", currentPrefix);
+} else {
+  if (ba == null) {
+    localStorage.setItem("backendAddress", "");
+  }
 }

--- a/service/conf/environmentConfig.go
+++ b/service/conf/environmentConfig.go
@@ -15,6 +15,8 @@ import (
 
 type Params struct {
 	Address              string `id:"address" short:"a" default:"0.0.0.0:2017" desc:"Listening address"`
+	Socket               string `id:"socket" desc:"Unix socket path for listening"`
+	BaseUrl              string `id:"baseurl" default:"/" desc:"Base URL path prefix"`
 	V2rayBin             string `id:"v2ray-bin" short:"b" desc:"Executable v2ray binary path. Auto-detect if put it empty."`
 	CoreType             string `id:"core-type" desc:"Specify core type: v2ray or xray. Required when using custom v2ray-bin path."`
 	Config               string `id:"config" short:"c" desc:"v2rayA configuration directory"`
@@ -55,6 +57,16 @@ func initFunc() {
 	if err != nil {
 		if err.Error() != "unexpected word while parsing flags: '-test.v'" {
 			log2.Fatal(err)
+		}
+	}
+	if params.BaseUrl == "" {
+		params.BaseUrl = "/"
+	} else {
+		if !strings.HasPrefix(params.BaseUrl, "/") {
+			params.BaseUrl = "/" + params.BaseUrl
+		}
+		if params.BaseUrl != "/" {
+			params.BaseUrl = strings.TrimSuffix(params.BaseUrl, "/")
 		}
 	}
 	if params.ShowVersion {

--- a/service/server/router/index.go
+++ b/service/server/router/index.go
@@ -93,7 +93,18 @@ func safeStatigzHandler(fsys fs.FS) (http.Handler, bool) {
 	return handler, true
 }
 
-func registerEmbeddedRoute(r *gin.Engine, routePrefix string, fsCandidates ...fs.FS) bool {
+func registerEmbeddedRoute(r gin.IRoutes, routePrefix string, fsCandidates ...fs.FS) bool {
+	prefix := ""
+	if group, ok := r.(*gin.RouterGroup); ok {
+		prefix = group.BasePath()
+	} else if engine, ok := r.(*gin.Engine); ok {
+		prefix = engine.BasePath()
+	}
+	staticPrefix := filepath.ToSlash(filepath.Join(prefix, routePrefix))
+	if !strings.HasPrefix(staticPrefix, "/") {
+		staticPrefix = "/" + staticPrefix
+	}
+
 	for _, candidate := range fsCandidates {
 		if candidate == nil {
 			continue
@@ -104,7 +115,7 @@ func registerEmbeddedRoute(r *gin.Engine, routePrefix string, fsCandidates ...fs
 			continue
 		}
 
-		stripped := http.StripPrefix(routePrefix, handler)
+		stripped := http.StripPrefix(staticPrefix, handler)
 		r.GET(routePrefix+"/*w", func(c *gin.Context) {
 			stripped.ServeHTTP(c.Writer, c.Request)
 		})
@@ -114,7 +125,7 @@ func registerEmbeddedRoute(r *gin.Engine, routePrefix string, fsCandidates ...fs
 	return false
 }
 
-func ServeGUI(r *gin.Engine) {
+func ServeGUI(r gin.IRoutes) {
 	webDir := conf.GetEnvironmentConfig().WebDir
 	if webDir == "" {
 		webFS, err := fs.Sub(webRoot, "web")
@@ -192,6 +203,11 @@ func ServeGUI(r *gin.Engine) {
 
 	app := conf.GetEnvironmentConfig()
 
+	if app.Socket != "" {
+		log.Alert("v2rayA is listening at unix:%v", app.Socket)
+		return
+	}
+
 	ip, port, _ := net.SplitHostPort(app.Address)
 	addrs, err := net.InterfaceAddrs()
 	if net.ParseIP(ip).IsUnspecified() && err == nil {
@@ -225,7 +241,9 @@ func Run() error {
 	corsConfig.AddAllowHeaders("Authorization", common.RequestIdHeader)
 	corsConfig.AddExposeHeaders("Content-Disposition")
 	engine.Use(cors.New(corsConfig))
-	noAuth := engine.Group("api",
+	app := conf.GetEnvironmentConfig()
+	root := engine.Group(app.BaseUrl)
+	noAuth := root.Group("api",
 		nocache,
 		reqCache.ReqCache,
 	)
@@ -235,7 +253,7 @@ func Run() error {
 		noAuth.GET("account", controller.GetAccount)
 		noAuth.POST("account", controller.PostAccount)
 	}
-	auth := engine.Group("api",
+	auth := root.Group("api",
 		nocache,
 		func(ctx *gin.Context) {
 			if !configure.HasAnyAccounts() {
@@ -292,13 +310,27 @@ func Run() error {
 		auth.GET("networkInterfaces", controller.GetNetworkInterfaces)
 	}
 
-	ServeGUI(engine)
+	ServeGUI(root)
 
-	addr := conf.GetEnvironmentConfig().Address
-	l, err := net.Listen("tcp", addr)
-	if err != nil {
-		return fmt.Errorf("router: failed to listen on %v: %w", addr, err)
+	var l net.Listener
+	var err error
+	if app.Socket != "" {
+		_ = os.Remove(app.Socket)
+		l, err = net.Listen("unix", app.Socket)
+		if err != nil {
+			return fmt.Errorf("router: failed to listen on unix socket %v: %w", app.Socket, err)
+		}
+		if err = os.Chmod(app.Socket, 0777); err != nil {
+			log.Warn("failed to chmod unix socket %v: %v", app.Socket, err)
+		}
+	} else {
+		addr := app.Address
+		l, err = net.Listen("tcp", addr)
+		if err != nil {
+			return fmt.Errorf("router: failed to listen on %v: %w", addr, err)
+		}
 	}
+
 
 	srv := &http.Server{Handler: engine}
 	httpServerMu.Lock()


### PR DESCRIPTION
This PR adds **Unix Domain Socket (UDS)** listening and **BaseUrl** subpath support to v2rayA, primarily adapting for **FnOS gateway** and similar reverse-proxy environments.
**Why this is needed:**
* **UDS Support**: Avoids exposing TCP ports locally, allowing safer and more efficient Unix socket communication with local gateways.
* **BaseUrl Support**: Fixes `404 Not Found` issues for web static assets (`/static/*`) and WebSockets (`/api/message`) when v2rayA is hosted under a reverse-proxy subpath (e.g. `https://nas.local/v2raya-sub/`).
**Key Changes:**
* **Go Backend**:
  * Added `V2RAYA_SOCKET`/`--socket` and `V2RAYA_BASEURL`/`--baseurl` options.
  * Mounted routes (`auth`, `noAuth`, and `ServeGUI`) under the `BaseUrl` group.
  * Enabled `net.Listen("unix", ...)` and `chmod 0777` on the socket file.
  * Adapted `registerEmbeddedRoute` to dynamically strip the `BasePath` prefix from static assets.
* **Frontend GUI**:
  * Adjusted `connectWsMessage` and `backendPort.js` to dynamically detect and use the subpath prefix for API & WS connections.
  * Relaxed the input verification pattern in server address settings to support relative path prefixes.
**Compatibility Guarantee & Test Proofs:**
* **Strict Backward Compatibility**: 
  We have conducted comprehensive regression testing on the default startup scenario. When running without the new UDS (`--socket`) or BaseUrl (`--baseurl`) options, v2rayA behaves **100% identically** as before—strictly keeping TCP listening at `0.0.0.0:2017` and root routing at `/`. There is absolutely zero deviation in API endpoints or WebSocket handshakes under default configurations, guaranteeing a safe upgrade paths with no regressions.


* **Test Screenshots**:


  * **Test 1: Default TCP Mode Verification (100% Normal)**
    <img width="600" height="400" alt="Default TCP Mode Verification" src="https://github.com/user-attachments/assets/063d8b23-9a3e-45b3-8d23-6425ec37f427" />


  * **Test 2: Unix Domain Socket + BaseUrl Subpath Mode Verification (100% Normal)**
    <img width="600" height="400" alt="UDS and BaseUrl Mode Verification - Page Rendering" src="https://github.com/user-attachments/assets/3661f64f-f843-408a-916e-97a2dcb808d3" />
    <img width="600" height="400" alt="UDS and BaseUrl Mode Verification - WebSocket Logs" src="https://github.com/user-attachments/assets/9422e149-7f12-4193-8765-d083a98a4066" />

