### PR TITLE
fix(gui): keep dark background across full page height

### DIFF
--- a/gui/src/App.vue
+++ b/gui/src/App.vue
@@ -647,6 +647,7 @@ export default {
     },
     applyThemeClass() {
       document.body.classList.toggle('theme-dark', this.isDarkTheme);
+      document.documentElement.classList.toggle('theme-dark', this.isDarkTheme);
     },
     toggleTheme() {
       const order = ['auto', 'light', 'dark'];
@@ -705,7 +706,7 @@ html {
   //  }
 
   #app {
-    height: calc(100vh - 3.25rem);
+    min-height: calc(100vh - 3.25rem);
     /*overflow-y: auto;*/
     //overflow-scrolling: touch;
     //-webkit-overflow-scrolling: touch;


### PR DESCRIPTION
## Summary

- Change the app container from fixed viewport height to minimum viewport height, allowing it to grow with page content.
- Apply the dark theme class to both `body` and `html` so the root page background stays dark when scrolling beyond the first viewport.

## Verification

- Built the frontend production assets successfully.
- Built `v2raya.exe` and verified the fix manually on the service UI.
- Ran `git diff --check`.