### PR TITLE
fix(db): fix missing `remarks` and `auto_select` fields in subscription

### DIFF
--- a/service/db/listOp.go
+++ b/service/db/listOp.go
@@ -39,12 +39,17 @@ func ListSet(bucket string, key string, index int, val interface{}) (err error) 
 		}
 		parsed := gjson.ParseBytes(b)
 		address := parsed.Get("address").String()
+		remarks := parsed.Get("remarks").String()
 		status := parsed.Get("status").String()
 		info := parsed.Get("info").String()
+		autoSelect := 0
+		if parsed.Get("autoSelect").Bool() {
+			autoSelect = 1
+		}
 
 		result, err := db.Exec(
-			"UPDATE subscriptions SET address = ?, status = ?, info = ?, updated_at = CURRENT_TIMESTAMP WHERE sort = ?",
-			address, status, info, index,
+			"UPDATE subscriptions SET address = ?, remarks = ?, status = ?, info = ?, auto_select = ?, updated_at = CURRENT_TIMESTAMP WHERE sort = ?",
+			address, remarks, status, info, autoSelect, index,
 		)
 		if err != nil {
 			return err
@@ -94,10 +99,11 @@ func ListGet(bucket string, key string, index int) (b []byte, err error) {
 		return []byte(configJSON), nil
 
 	case "touch/subscriptions":
-		var address, status, info string
+		var address, remarks, status, info string
+		var autoSelectInt int
 		err = db.QueryRow(
-			"SELECT address, status, info FROM subscriptions WHERE sort = ?", index,
-		).Scan(&address, &status, &info)
+			"SELECT address, remarks, status, info, auto_select FROM subscriptions WHERE sort = ?", index,
+		).Scan(&address, &remarks, &status, &info, &autoSelectInt)
 		if err == sql.ErrNoRows {
 			return nil, fmt.Errorf("ListGet: can't get element from an empty list")
 		}
@@ -125,8 +131,9 @@ func ListGet(bucket string, key string, index int) (b []byte, err error) {
 		}
 
 		serversJSON := "[" + strings.Join(servers, ",") + "]"
-		result := fmt.Sprintf(`{"address":"%s","status":"%s","info":"%s","servers":%s}`,
-			address, status, info, serversJSON)
+		autoSelect := autoSelectInt != 0
+		result := fmt.Sprintf(`{"remarks":"%s","address":"%s","status":"%s","info":"%s","servers":%s,"autoSelect":%v}`,
+			remarks, address, status, info, serversJSON, autoSelect)
 		return []byte(result), nil
 
 	default:
@@ -181,16 +188,21 @@ func ListAppend(bucket string, key string, val interface{}) (err error) {
 		if parsed.IsArray() {
 			for _, item := range parsed.Array() {
 				address := item.Get("address").String()
+				remarks := item.Get("remarks").String()
 				status := item.Get("status").String()
 				info := item.Get("info").String()
+				autoSelect := 0
+				if item.Get("autoSelect").Bool() {
+					autoSelect = 1
+				}
 
 				var maxSort int
 				db.QueryRow("SELECT COALESCE(MAX(sort), -1) FROM subscriptions").Scan(&maxSort)
 				newSort := maxSort + 1
 
 				res, err := db.Exec(
-					"INSERT INTO subscriptions (address, status, info, sort) VALUES (?, ?, ?, ?)",
-					address, status, info, newSort,
+					"INSERT INTO subscriptions (address, remarks, status, info, auto_select, sort) VALUES (?, ?, ?, ?, ?, ?)",
+					address, remarks, status, info, autoSelect, newSort,
 				)
 				if err != nil {
 					return err
@@ -245,7 +257,7 @@ func ListGetAll(bucket string, key string) (list [][]byte, err error) {
 		return list, rows.Err()
 
 	case "touch/subscriptions":
-		rows, err := db.Query("SELECT id, address, status, info FROM subscriptions ORDER BY sort")
+		rows, err := db.Query("SELECT id, address, remarks, status, info, auto_select FROM subscriptions ORDER BY sort")
 		if err != nil {
 			return nil, err
 		}
@@ -253,8 +265,9 @@ func ListGetAll(bucket string, key string) (list [][]byte, err error) {
 
 		for rows.Next() {
 			var id int64
-			var address, status, info string
-			if err := rows.Scan(&id, &address, &status, &info); err != nil {
+			var address, remarks, status, info string
+			var autoSelectInt int
+			if err := rows.Scan(&id, &address, &remarks, &status, &info, &autoSelectInt); err != nil {
 				return nil, err
 			}
 
@@ -278,8 +291,9 @@ func ListGetAll(bucket string, key string) (list [][]byte, err error) {
 			serverRows.Close()
 
 			serversJSON := "[" + strings.Join(servers, ",") + "]"
-			result := fmt.Sprintf(`{"address":"%s","status":"%s","info":"%s","servers":%s}`,
-				address, status, info, serversJSON)
+			autoSelect := autoSelectInt != 0
+			result := fmt.Sprintf(`{"remarks":"%s","address":"%s","status":"%s","info":"%s","servers":%s,"autoSelect":%v}`,
+				remarks, address, status, info, serversJSON, autoSelect)
 			list = append(list, []byte(result))
 		}
 		return list, rows.Err()

--- a/service/db/migrate.go
+++ b/service/db/migrate.go
@@ -274,8 +274,8 @@ func migrateSubscriptions(data []byte, tx *sql.Tx) (map[int64]int64, error) {
 	subIDMap := make(map[int64]int64, len(results))
 
 	subStmt, err := tx.Prepare(`
-		INSERT INTO subscriptions (address, status, info, sort)
-		VALUES (?, ?, ?, ?)
+		INSERT INTO subscriptions (address, remarks, status, info, auto_select, sort)
+		VALUES (?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return nil, err
@@ -293,10 +293,15 @@ func migrateSubscriptions(data []byte, tx *sql.Tx) (map[int64]int64, error) {
 
 	for i, r := range results {
 		address := r.Get("address").String()
+		remarks := r.Get("remarks").String()
 		status := r.Get("status").String()
 		info := r.Get("info").String()
+		autoSelect := 0
+		if r.Get("autoSelect").Bool() {
+			autoSelect = 1
+		}
 
-		res, err := subStmt.Exec(address, status, info, i)
+		res, err := subStmt.Exec(address, remarks, status, info, autoSelect, i)
 		if err != nil {
 			return nil, fmt.Errorf("failed to insert subscription %d: %w", i, err)
 		}

--- a/service/db/schema.go
+++ b/service/db/schema.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+	"fmt"
 
 	"github.com/v2rayA/v2rayA/pkg/util/log"
 )
@@ -34,8 +35,10 @@ CREATE TABLE IF NOT EXISTS servers (
 CREATE TABLE IF NOT EXISTS subscriptions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     address TEXT NOT NULL DEFAULT '',
+    remarks TEXT NOT NULL DEFAULT '',
     status TEXT NOT NULL DEFAULT '',
     info TEXT DEFAULT '',
+    auto_select INTEGER NOT NULL DEFAULT 0,
     filter TEXT DEFAULT '',
     group_id TEXT DEFAULT '',
     sort INTEGER NOT NULL DEFAULT 0,
@@ -81,5 +84,37 @@ func InitSchema(db *sql.DB) error {
 		return err
 	}
 	log.Info("Database schema initialized successfully")
+	return nil
+}
+
+// MigrateSchema applies incremental schema migrations for existing databases.
+// Unlike InitSchema (which uses CREATE TABLE IF NOT EXISTS), this handles
+// ALTER TABLE additions for columns added after the initial schema version.
+func MigrateSchema(db *sql.DB) error {
+	// Check if remarks column exists (added after initial schema)
+	var count int
+	err := db.QueryRow("SELECT COUNT(*) FROM pragma_table_info('subscriptions') WHERE name = 'remarks'").Scan(&count)
+	if err != nil {
+		return fmt.Errorf("failed to check for remarks column: %w", err)
+	}
+	if count == 0 {
+		log.Info("Adding remarks column to subscriptions table")
+		if _, err := db.Exec("ALTER TABLE subscriptions ADD COLUMN remarks TEXT NOT NULL DEFAULT ''"); err != nil {
+			return fmt.Errorf("failed to add remarks column: %w", err)
+		}
+	}
+
+	// Check if auto_select column exists (added after initial schema)
+	err = db.QueryRow("SELECT COUNT(*) FROM pragma_table_info('subscriptions') WHERE name = 'auto_select'").Scan(&count)
+	if err != nil {
+		return fmt.Errorf("failed to check for auto_select column: %w", err)
+	}
+	if count == 0 {
+		log.Info("Adding auto_select column to subscriptions table")
+		if _, err := db.Exec("ALTER TABLE subscriptions ADD COLUMN auto_select INTEGER NOT NULL DEFAULT 0"); err != nil {
+			return fmt.Errorf("failed to add auto_select column: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/service/db/sqlite.go
+++ b/service/db/sqlite.go
@@ -91,6 +91,11 @@ func initDB() {
 	if err := InitSchema(sqlDB); err != nil {
 		log.Fatal("InitSchema: %v", err)
 	}
+
+	// Apply incremental schema migrations for existing databases
+	if err := MigrateSchema(sqlDB); err != nil {
+		log.Fatal("MigrateSchema: %v", err)
+	}
 }
 
 // GetDB returns the singleton SQLite database connection


### PR DESCRIPTION
## Summary
The SubscriptionRaw Go struct has Remarks and AutoSelect fields, but the SQLite schema and CRUD operations never included them after the BoltDB→SQLite migration. This caused:
- GET /api/touch returning subscriptions without remarks
- PATCH /api/subscription silently dropping remark/autoSelect updates  
## Changes
- schema.go — added remarks and auto_select columns to subscriptions table; added MigrateSchema() to auto-heal existing databases via ALTER TABLE
- listOp.go — ListSet/ListGet/ListAppend/ListGetAll now include remarks and autoSelect in SQL and JSON reconstruction
- migrate.go — BoltDB→SQLite migration now transfers remarks and autoSelect
- sqlite.go — initDB() calls MigrateSchema() after InitSchema()