### PR TITLE
fix: update subscription servers by real sub id

### DIFF
--- a/service/db/listOp.go
+++ b/service/db/listOp.go
@@ -38,6 +38,13 @@ func ListSet(bucket string, key string, index int, val interface{}) (err error) 
 			return err
 		}
 		parsed := gjson.ParseBytes(b)
+		var subID int64
+		if err := db.QueryRow("SELECT id FROM subscriptions WHERE sort = ?", index).Scan(&subID); err != nil {
+			if err == sql.ErrNoRows {
+				return fmt.Errorf("ListSet: subscription at index %d not found", index)
+			}
+			return err
+		}
 		address := parsed.Get("address").String()
 		remarks := parsed.Get("remarks").String()
 		status := parsed.Get("status").String()
@@ -48,8 +55,8 @@ func ListSet(bucket string, key string, index int, val interface{}) (err error) 
 		}
 
 		result, err := db.Exec(
-			"UPDATE subscriptions SET address = ?, remarks = ?, status = ?, info = ?, auto_select = ?, updated_at = CURRENT_TIMESTAMP WHERE sort = ?",
-			address, remarks, status, info, autoSelect, index,
+			"UPDATE subscriptions SET address = ?, remarks = ?, status = ?, info = ?, auto_select = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+			address, remarks, status, info, autoSelect, subID,
 		)
 		if err != nil {
 			return err
@@ -60,7 +67,6 @@ func ListSet(bucket string, key string, index int, val interface{}) (err error) 
 		}
 
 		// Update servers within this subscription
-		subID := int64(index + 1)
 		db.Exec("DELETE FROM servers WHERE type = 'subscription_server' AND sub_id = ?", subID)
 
 		servers := parsed.Get("servers").Array()


### PR DESCRIPTION
**Summary**
- Fix subscription refresh writing servers to the wrong subscription after deleting and adding subscriptions.

**Root Cause**
- After deleting a subscription and adding a new one, `subscriptions.id` no longer matches `index + 1`.
- The refresh path used `index + 1` as `sub_id`, so rebuilt servers could be written under the wrong subscription.

**Fix**
- Query the real `subscriptions.id` by `sort = index`.
- Use the real ID when rebuilding `subscription_server` rows.