### PR TITLE
fix(core): ignore empty sniffing exclusions

### DIFF
--- a/service/kernel/v2ray/template_inbound.go
+++ b/service/kernel/v2ray/template_inbound.go
@@ -286,18 +286,28 @@ func (t *Template) setInbound(setting *configure.Setting) error {
 	// Set up domain sniffing
 	if setting.InboundSniffing != configure.InboundSniffingDisable && setting.InboundSniffing != "" {
 		enableSniffingRouteOnly := configure.GetSettingNotNil().RouteOnly
-		domainsExcludedText := configure.GetDomainsExcluded()
+		domainsExcluded := splitNonEmptyLines(configure.GetDomainsExcluded())
 		for i := len(t.Inbounds) - 1; i >= 0; i-- {
 			if setting.InboundSniffing == configure.InboundSniffingHttpTLS {
 				t.Inbounds[i].Sniffing.DestOverride = []string{"http", "tls"}
 			} else {
 				t.Inbounds[i].Sniffing.DestOverride = []string{"http", "tls", "quic"}
 			}
-			t.Inbounds[i].Sniffing.DomainsExcluded = strings.Split(domainsExcludedText, "\n")
+			t.Inbounds[i].Sniffing.DomainsExcluded = domainsExcluded
 			t.Inbounds[i].Sniffing.Enabled = true
 			t.Inbounds[i].Sniffing.RouteOnly = enableSniffingRouteOnly
 		}
 
 	}
 	return nil
+}
+
+func splitNonEmptyLines(text string) []string {
+	var lines []string
+	for _, line := range strings.Split(text, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
 }


### PR DESCRIPTION
When the “Domains Excluded” setting is empty (by default), the current code uses:

```go
strings.Split("", "\n")
```

This produces `[]string{""}`, so the generated Xray configuration contains:

```json
"domainsExcluded": [""]
```

Xray parses exclusion entries as substring domain rules by default. An empty substring matches every sniffed domain, so this configuration **silently disables destination override for all HTTP and TLS traffic**.

This is especially visible in GFWList REDIRECT mode: the router only sees the original destination IP instead of the sniffed hostname, misses domain-based GFW rules, and falls through to the final direct rule. SOCKS clients using hostnames may still work, which makes the failure appear specific to transparent proxying.

P.S. Code is generated with AI Agent. Although the code has been tested by myself, please still review it carefully.
