### PR TITLE
fix: preserve assets when XDG data and runtime paths match

### DIFF
--- a/service/kernel/v2ray/asset/asset.go
+++ b/service/kernel/v2ray/asset/asset.go
@@ -79,6 +79,12 @@ func GetV2rayLocationAsset(filename string) (string, error) {
 			if err != nil {
 				return "", err
 			}
+			// On macOS, XDG data and runtime directories default to the same
+			// Application Support directory. Avoid replacing the asset with a
+			// symlink to itself when both paths resolve to the same location.
+			if filepath.Clean(fullpath) == filepath.Clean(runtimepath) {
+				return fullpath, nil
+			}
 			os.Remove(runtimepath)
 			err = os.Symlink(fullpath, runtimepath)
 			if err != nil {

--- a/service/kernel/v2ray/asset/asset_test.go
+++ b/service/kernel/v2ray/asset/asset_test.go
@@ -1,0 +1,87 @@
+package asset
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/adrg/xdg"
+)
+
+func TestGetV2rayLocationAssetKeepsAssetWhenDataAndRuntimeDirsMatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG runtime symlinks are not used on Windows")
+	}
+
+	baseDir := t.TempDir()
+	setXDGAssetDirs(t, baseDir, baseDir)
+
+	assetPath := filepath.Join(baseDir, "v2raya", "geoip.dat")
+	if err := os.MkdirAll(filepath.Dir(assetPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const content = "geoip data"
+	if err := os.WriteFile(assetPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	gotPath, err := GetV2rayLocationAsset("geoip.dat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != assetPath {
+		t.Fatalf("asset path = %q, want %q", gotPath, assetPath)
+	}
+
+	info, err := os.Lstat(assetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("asset was replaced by a self-referential symlink")
+	}
+	gotContent, err := os.ReadFile(assetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotContent) != content {
+		t.Fatalf("asset content = %q, want %q", gotContent, content)
+	}
+}
+
+func TestGetV2rayLocationAssetDoesNotCreateSelfSymlinkForMissingAsset(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG runtime symlinks are not used on Windows")
+	}
+
+	baseDir := t.TempDir()
+	setXDGAssetDirs(t, baseDir, baseDir)
+
+	assetPath := filepath.Join(baseDir, "v2raya", "geosite.dat")
+	gotPath, err := GetV2rayLocationAsset("geosite.dat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != assetPath {
+		t.Fatalf("asset path = %q, want %q", gotPath, assetPath)
+	}
+	if _, err := os.Lstat(assetPath); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("missing asset should not be created as a symlink, got error %v", err)
+	}
+}
+
+func setXDGAssetDirs(t *testing.T, dataHome, runtimeDir string) {
+	t.Helper()
+
+	// Register this before t.Setenv so the environment is restored before
+	// xdg reloads its package-level directory state during cleanup.
+	t.Cleanup(xdg.Reload)
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	t.Setenv("XDG_DATA_DIRS", "")
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	t.Setenv("XRAY_LOCATION_ASSET", "")
+	xdg.Reload()
+}


### PR DESCRIPTION
## Summary

- preserve existing assets when the XDG data and runtime paths are the same
- avoid creating self-referential symlinks for missing assets
- add regression coverage for both existing and missing asset files

## Problem

On macOS, `adrg/xdg` defaults both `DataHome` and `RuntimeDir` to `~/Library/Application Support`. As a result, `GetV2rayLocationAsset` can resolve both `fullpath` and `runtimepath` to the same file.

The current code removes `runtimepath` and then symlinks it to `fullpath`. When the paths match, this replaces a valid `geoip.dat` or `geosite.dat` with a symlink to itself. Subsequent asset checks fail with:

```
geoip.dat or geosite.dat file does not exists
```

This change returns the asset path directly when the cleaned paths match, before removing or creating any symlink.

## Testing

- `go test ./kernel/v2ray/asset`
- `go test ./kernel/v2ray/...`
- verified the bundled core can parse a config referencing both `geoip:private` and `geosite:cn` on macOS

The broader `go test ./...` still has unrelated existing failures involving missing generated `server/router/web` assets, an import cycle in `common` tests, and platform-specific paths in the `gopeed` test.
