### PR TITLE
fix(db): subscription update duplicates server list on installs migrated from BoltDB

### DIFF
--- a/service/db/listOp.go
+++ b/service/db/listOp.go
@@ -66,8 +66,18 @@ func ListSet(bucket string, key string, index int, val interface{}) (err error) 
 			return fmt.Errorf("ListSet: subscription at index %d not found", index)
 		}
 
-		// Update servers within this subscription
-		db.Exec("DELETE FROM servers WHERE type = 'subscription_server' AND sub_id = ?", subID)
+		// Update servers within this subscription.
+		// Clean up outbound_connections first to satisfy foreign key constraint;
+		// otherwise the delete fails and the insert below duplicates the list.
+		if _, err := db.Exec(`
+			DELETE FROM outbound_connections
+			WHERE server_id IN (SELECT id FROM servers WHERE type = 'subscription_server' AND sub_id = ?)
+		`, subID); err != nil {
+			return fmt.Errorf("ListSet: failed to clear outbound connections of subscription %d: %w", index, err)
+		}
+		if _, err := db.Exec("DELETE FROM servers WHERE type = 'subscription_server' AND sub_id = ?", subID); err != nil {
+			return fmt.Errorf("ListSet: failed to clear old servers of subscription %d: %w", index, err)
+		}
 
 		servers := parsed.Get("servers").Array()
 		for j, s := range servers {


### PR DESCRIPTION
## Problem

On installs migrated from BoltDB to SQLite, every subscription update **duplicates the subscription's entire server list**. A user with 6 servers sees 13 after one update (6 fresh + the old rows, interleaved), and the list keeps growing with every subsequent update.

Root cause in `db/listOp.go` (`ListSet`, `touch/subscriptions` case):

```go
// Update servers within this subscription
db.Exec("DELETE FROM servers WHERE type = 'subscription_server' AND sub_id = ?", subID)
```

The error is discarded. The BoltDB→SQLite migration creates `outbound_connections` rows that hold a `FOREIGN KEY (server_id) REFERENCES servers(id)` on the connected server, and `PRAGMA foreign_keys=ON` is set — so this DELETE fails with `FOREIGN KEY constraint failed` whenever any server of the subscription is connected (i.e., for essentially every real user). The failure is silent, and the subsequent INSERTs append the fresh list alongside the old rows, producing duplicate `(sub_id, sort)` pairs.

Fresh (non-migrated) installs are unaffected because nothing after the migration writes `outbound_connections`, which is why this survives testing on clean setups.

## Fix

Delete the referencing `outbound_connections` rows before deleting the subscription's servers — the exact pattern `ListRemove` already uses ("Clean up outbound_connections first to satisfy foreign key constraint") — and propagate errors from both DELETEs instead of ignoring them.

The first successful update after this fix also self-heals already-duplicated lists, since the whole server set is rewritten.

## Testing

- Reproduced the constraint failure directly against a real migrated database: `DELETE FROM servers WHERE type='subscription_server' AND sub_id=1;` → `FOREIGN KEY constraint failed`; with the fix's ordering it succeeds.
- Two-phase end-to-end test against the real binary and HTTP API: import + connect on a fresh config, then insert an `outbound_connections` row referencing the connected server (simulating the migration artifact), then `PUT /api/subscription` with a changed list. Before the fix this leaves duplicated `(sub_id, sort)` rows; after the fix the table contains exactly the fresh list with distinct sort values, and `go vet` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3fRH7VjZDa4bKTHjTQ7ZL
