### PR TITLE
fix(iptables): exempt DNS module port from generic TPROXY hijack (local UDP DNS dead in tproxy mode)

### DIFF
--- a/service/kernel/iptables/tproxy.go
+++ b/service/kernel/iptables/tproxy.go
@@ -89,6 +89,10 @@ iptables -w 2 -t mangle -A TP_OUT -p udp -m addrtype --src-type LOCAL ! --dst-ty
 iptables -w 2 -t mangle -A TP_PRE -i lo -m mark ! --mark 0x40/0xc0 -j RETURN
 iptables -w 2 -t mangle -A TP_PRE -p tcp -m addrtype ! --src-type LOCAL ! --dst-type LOCAL -j TP_RULE
 iptables -w 2 -t mangle -A TP_PRE -p udp -m addrtype ! --src-type LOCAL ! --dst-type LOCAL -j TP_RULE
+# 本机 DNS 查询在 nat OUTPUT 已被 REDIRECT 改写端口（53→52353），经 lo 重入时
+# 带着 0x40 标记但端口不再是 53，必须放行，否则命中通用 TPROXY 规则被劫持到 52345
+iptables -w 2 -t mangle -A TP_PRE -p tcp --dport 52353 -j RETURN
+iptables -w 2 -t mangle -A TP_PRE -p udp --dport 52353 -j RETURN
 # DNS 流量重定向到新 DNS 模块端口 52353（必须在通用 TPROXY 规则之前）
 iptables -w 2 -t mangle -A TP_PRE -p tcp -m mark --mark 0x40/0xc0 --dport 53 -j TPROXY --on-port 52353 --on-ip 127.2.0.17
 iptables -w 2 -t mangle -A TP_PRE -p udp -m mark --mark 0x40/0xc0 --dport 53 -j TPROXY --on-port 52353 --on-ip 127.2.0.17
@@ -155,6 +159,10 @@ ip6tables -w 2 -t mangle -A TP_OUT -p udp -m addrtype --src-type LOCAL ! --dst-t
 ip6tables -w 2 -t mangle -A TP_PRE -i lo -m mark ! --mark 0x40/0xc0 -j RETURN
 ip6tables -w 2 -t mangle -A TP_PRE -p tcp -m addrtype ! --src-type LOCAL ! --dst-type LOCAL -j TP_RULE
 ip6tables -w 2 -t mangle -A TP_PRE -p udp -m addrtype ! --src-type LOCAL ! --dst-type LOCAL -j TP_RULE
+# 本机 DNS 查询在 nat OUTPUT 已被 REDIRECT 改写端口（53→52353），经 lo 重入时
+# 带着 0x40 标记但端口不再是 53，必须放行，否则命中通用 TPROXY 规则被劫持到 52345
+ip6tables -w 2 -t mangle -A TP_PRE -p tcp --dport 52353 -j RETURN
+ip6tables -w 2 -t mangle -A TP_PRE -p udp --dport 52353 -j RETURN
 # DNS 流量重定向到新 DNS 模块端口 52353（必须在通用 TPROXY 规则之前）
 ip6tables -w 2 -t mangle -A TP_PRE -p tcp -m mark --mark 0x40/0xc0 --dport 53 -j TPROXY --on-port 52353 --on-ip ::1
 ip6tables -w 2 -t mangle -A TP_PRE -p udp -m mark --mark 0x40/0xc0 --dport 53 -j TPROXY --on-port 52353 --on-ip ::1
@@ -322,6 +330,9 @@ func (t *nftTproxy) GetSetupCommands() Setter {
     chain tp_pre {
         iifname "lo" mark & 0xc0 != 0x40 return
         meta l4proto { tcp, udp } fib saddr type != local fib daddr type != local jump tp_rule
+        # 本机 DNS 查询在 nat OUTPUT 已被 REDIRECT 改写端口（53→52353），经 lo 重入时
+        # 带着 0x40 标记但端口不再是 53，必须放行，否则命中通用 TPROXY 规则被劫持到 52345
+        meta l4proto { tcp, udp } th dport 52353 return
         # DNS 流量重定向到新 DNS 模块端口 52353（必须在通用 TPROXY 规则之前）
         meta l4proto { tcp, udp } mark & 0xc0 == 0x40 th dport 53 tproxy ip to 127.2.0.17:52353
         meta l4proto { tcp, udp } mark & 0xc0 == 0x40 th dport 53 tproxy ip6 to [::1]:52353


### PR DESCRIPTION
## Problem

With transparent proxy in TPROXY mode, **all locally originated UDP DNS queries time out**, which makes transparent proxy appear completely broken (no domain resolves, so no site loads). Reproduce on the current main (also present in the v2.4.8 binary):

1. Enable transparent proxy (tproxy mode) with the DNS module active.
2. On the same host: `dig www.google.com` (or any domain, against any server) → times out.
3. `dig +tcp www.google.com` → works, which is the diagnostic tell.

## Root cause

Three rule sets interact badly for host-originated DNS:

1. mangle OUTPUT: `DNS_MARK` stamps DNS packets with fwmark `0x40` (loop-protection/marking).
2. nat OUTPUT: `REDIRECT --to-port 52353` rewrites the destination port **53 → 52353**.
3. The fwmark reroutes the packet through loopback, where it re-enters `TP_PRE`. The DNS TPROXY rule there matches `--dport 53` only — but the port is already 52353, so the packet falls through to the **generic** mark-0x40 TPROXY rule and is diverted to the transparent proxy port **52345** instead of the DNS module. The query dies there.

TCP DNS survives because the core accepts the hijacked connection and proxies it onward to the original destination (127.0.0.1:52353), which still reaches the DNS module. UDP has no such rescue. Queries also work for a brief window during rule setup (before the nat REDIRECT rules land), which can mask the bug in quick tests.

Observed on Ubuntu 24.04 with `IPTABLES_MODE=legacy` in the official docker deployment: the nat REDIRECT counters increment, yet the DNS module logs zero queries after startup and its UDP socket receive queue stays empty.

## Fix

Add `RETURN` rules for `dport 52353` in `TP_PRE` ahead of the TPROXY rules — in the legacy IPv4, legacy IPv6, and nftables variants — so DNS traffic already redirected to the DNS module is delivered untouched. Traffic from LAN clients still hits the `--dport 53` TPROXY rule as before (their port is not rewritten at that point), so the LAN path is unchanged.

## Verification

Before (rules as on main): `dig` against any resolver times out; `curl https://www.google.com` hangs on resolution.
After (with this patch): `dig www.google.com` → NOERROR, transparent proxy works for both foreign and direct sites; verified live by inserting the two RETURN rules into a broken ruleset, and again from a clean restart with the patched binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
