### PR TITLE
fix(webui): cannot save node configuration changes

### DIFF
--- a/gui/src/components/modalServer.vue
+++ b/gui/src/components/modalServer.vue
@@ -1512,8 +1512,8 @@ export default {
       return null;
     },
     generateURL(srcObj) {
-      let obj = {};
       let query = {};
+      let obj = {};
       let tmp;
       switch (srcObj.protocol) {
         case "vless":
@@ -1820,7 +1820,6 @@ export default {
           }
           return generateURL(tmp);
         case "anytls":
-          let query = {};
           if (srcObj.sni) {
             query.peer = srcObj.sni;
           }


### PR DESCRIPTION
Fix a bug existed in the main branch where any modifications to node content could not be saved via WebUI. The patch has been compiled and tested on version 2.4.9, and the save function works properly. Further testing is still required as potential side effects introduced by this patch remain unknown.
<img width="1744" height="1213" alt="image" src="https://github.com/user-attachments/assets/ea251f56-1ee9-4901-9f2c-39c370f9b8fd" />
