### PR TITLE
fix: map AnyTLS insecure query parameter

### DIFF
--- a/service/kernel/serverObj/anytls.go
+++ b/service/kernel/serverObj/anytls.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/v2rayA/v2rayA/kernel/coreObj"
 )
@@ -52,6 +53,7 @@ type anytlsSettings struct {
 	Port                 int    `json:"port"`
 	Password             string `json:"password"`
 	SNI                  string `json:"sni,omitempty"`
+	AllowInsecure        bool   `json:"allow_insecure,omitempty"`
 	MinIdleSessions      int    `json:"min_idle_sessions,omitempty"`
 	PinnedPeerCertSha256 string `json:"pinnedPeerCertSha256,omitempty"`
 	VerifyPeerCertByName string `json:"verifyPeerCertByName,omitempty"`
@@ -76,6 +78,7 @@ func (s *AnyTLS) Configuration(info PriorInfo) (c Configuration, err error) {
 		Port:                 s.Port,
 		Password:             password,
 		SNI:                  sni,
+		AllowInsecure:        isTruthy(q.Get("insecure")),
 		MinIdleSessions:      minIdle,
 		PinnedPeerCertSha256: q.Get("pinnedPeerCertSha256"),
 		VerifyPeerCertByName: q.Get("verifyPeerCertByName"),
@@ -92,6 +95,15 @@ func (s *AnyTLS) Configuration(info PriorInfo) (c Configuration, err error) {
 		},
 		UDPSupport: true,
 	}, nil
+}
+
+func isTruthy(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *AnyTLS) ExportToURL() string {

--- a/service/kernel/serverObj/anytls_test.go
+++ b/service/kernel/serverObj/anytls_test.go
@@ -1,0 +1,50 @@
+package serverObj
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestAnyTLSConfigurationMapsInsecure(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{value: "1", want: true},
+		{value: "true", want: true},
+		{value: "yes", want: true},
+		{value: "on", want: true},
+		{value: "0", want: false},
+		{value: "false", want: false},
+		{value: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("value_%s", tt.value), func(t *testing.T) {
+			server, err := ParseAnyTLSURL("anytls://password@example.com:443?insecure=" + tt.value + "#test")
+			if err != nil {
+				t.Fatalf("ParseAnyTLSURL() error = %v", err)
+			}
+
+			configuration, err := server.Configuration(PriorInfo{Tag: "test"})
+			if err != nil {
+				t.Fatalf("Configuration() error = %v", err)
+			}
+
+			var settings map[string]any
+			if err := json.Unmarshal(configuration.CoreOutbound.Settings.Inlined, &settings); err != nil {
+				t.Fatalf("unmarshal settings: %v", err)
+			}
+
+			got, present := settings["allow_insecure"].(bool)
+			if tt.want {
+				if !present || !got {
+					t.Fatalf("allow_insecure = %v, present = %v; want true", got, present)
+				}
+			} else if present {
+				t.Fatalf("allow_insecure unexpectedly present with value %v", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
AnyTLS links containing `insecure=1` now generate `allow_insecure: true` in the hybrid-core outbound settings, with regression coverage for common truthy values.

## Problem

A user-provided temporary third-party AnyTLS subscription exposed the issue. The reproduction source contained AnyTLS nodes; a representative node host was `y6x0v4mutx.yn33dfs2.sbs`. The token-bearing subscription URL is intentionally omitted.

When the imported links included `?insecure=1`, v2rayA accepted and displayed the nodes, but the generated hybrid-core configuration omitted the corresponding `allow_insecure` setting. The core then performed normal certificate verification and the nodes failed connectivity checks when the provider required insecure TLS verification.

## Root Cause

`AnyTLS.Configuration` extracted the password, SNI, idle-session, certificate-pinning, and peer-name parameters, but did not map the standard `insecure` query parameter to the hybrid-core setting `allow_insecure`.

## Solution

- Parse `insecure` using an explicit, case-insensitive truthy set: `1`, `true`, `yes`, and `on`.
- Emit `allow_insecure: true` only when requested; keep the field omitted for false or absent values so existing secure behavior is unchanged.
- Add a table-driven regression test covering all accepted truthy values and false/empty values.

This change is scoped to AnyTLS and does not globally disable TLS verification or include any provider credentials.

## Verification

- `go test ./kernel/serverObj` passed.
- `go build ./...` passed.
- `go test ./...` still has unrelated baseline failures: an existing `common` test import cycle and an existing `pkg/util/gopeed` temporary-directory test failure.