### PR TITLE
feat: manage subscription updates per source

### DIFF
--- a/gui/src/components/modalSetting.vue
+++ b/gui/src/components/modalSetting.vue
@@ -314,20 +314,6 @@
           v-model="pacAutoUpdateIntervalHour" custom-class="no-shadow" type="number" min="1"
           validation-icon=" iconfont icon-alert" style="flex: 1" />
       </b-field>
-      <b-field :label="$t('setting.autoUpdateSub')" label-position="on-border">
-        <b-select v-model="subscriptionAutoUpdateMode" expanded>
-          <option value="none">{{ $t("setting.options.off") }}</option>
-          <option value="auto_update">
-            {{ $t("setting.options.updateSubWhenStart") }}
-          </option>
-          <option value="auto_update_at_intervals">
-            {{ $t("setting.options.updateSubAtIntervals") }}
-          </option>
-        </b-select>
-        <cus-b-input v-if="subscriptionAutoUpdateMode === 'auto_update_at_intervals'" ref="autoUpdateSubInput"
-          v-model="subscriptionAutoUpdateIntervalHour" custom-class="no-shadow" type="number" min="1"
-          validation-icon=" iconfont icon-alert" style="flex: 1" />
-      </b-field>
       <b-field :label="$t('setting.preferModeWhenUpdate')" label-position="on-border">
         <b-select v-model="proxyModeWhenSubscribe" expanded>
           <option value="direct">
@@ -508,7 +494,6 @@ export default {
           Object.assign(this, res.data.data.setting);
           delete res.data.data["setting"];
           Object.assign(this, res.data.data);
-          this.subscriptionAutoUpdateTime = new Date(this.subscriptionAutoUpdateTime);
           this.pacAutoUpdateTime = new Date(this.pacAutoUpdateTime);
           // Get OS and isRoot info from version API
           this.$axios({
@@ -593,12 +578,6 @@ export default {
     },
     handleClickSubmit() {
       if (this.muxOn === "yes" && !this.$refs.muxinput.checkHtml5Validity()) {
-        return;
-      }
-      if (
-        this.subscriptionAutoUpdateMode === "auto_update_at_intervals" &&
-        !this.$refs.autoUpdateSubInput.checkHtml5Validity()
-      ) {
         return;
       }
       if (

--- a/gui/src/components/modalSubcription.vue
+++ b/gui/src/components/modalSubcription.vue
@@ -23,6 +23,29 @@
 	  >{{ $t("subscription.autoSelect") }}
 	</b-checkbox>
       </b-field>
+      <b-field :label="$t('setting.autoUpdateSub')">
+        <b-select v-model="which.autoUpdateMode" expanded>
+          <option value="none">{{ $t("setting.options.off") }}</option>
+          <option value="auto_update">
+            {{ $t("setting.options.updateSubWhenStart") }}
+          </option>
+          <option value="auto_update_at_intervals">
+            {{ $t("setting.options.updateSubAtIntervals") }}
+          </option>
+        </b-select>
+      </b-field>
+      <b-field
+        v-if="which.autoUpdateMode === 'auto_update_at_intervals'"
+        :label="$t('setting.options.updateSubAtIntervals')"
+      >
+        <b-input
+          ref="autoUpdateIntervalInput"
+          v-model.number="which.autoUpdateIntervalHour"
+          type="number"
+          min="1"
+          required
+        />
+      </b-field>
     </section>
     <footer class="modal-card-foot flex-end">
       <button class="button" type="button" @click="$parent.close()">
@@ -48,6 +71,15 @@ export default {
   },
   methods: {
     handleClickSubmit() {
+      if (
+        this.which.autoUpdateMode === "auto_update_at_intervals" &&
+        !this.$refs.autoUpdateIntervalInput.checkHtml5Validity()
+      ) {
+        return;
+      }
+      if (this.which.autoUpdateMode !== "auto_update_at_intervals") {
+        this.which.autoUpdateIntervalHour = 0;
+      }
       this.$emit("submit", this.which);
     },
   },

--- a/service/db/configure/configure.go
+++ b/service/db/configure/configure.go
@@ -127,6 +127,12 @@ func SetServer(index int, server *ServerRaw) (err error) {
 func SetSubscription(index int, subscription *SubscriptionRaw) (err error) {
 	return db.ListSet("touch", "subscriptions", index, subscription)
 }
+func MarkSubscriptionUpdateAttempt(databaseID int64) error {
+	return db.MarkSubscriptionUpdateAttempt(databaseID)
+}
+func GetSubscriptionIndexByID(databaseID int64) (int, error) {
+	return db.GetSubscriptionIndexByID(databaseID)
+}
 func SetSetting(setting *Setting) (err error) {
 	return db.Set("system", "setting", setting)
 }

--- a/service/db/configure/raw.go
+++ b/service/db/configure/raw.go
@@ -13,12 +13,16 @@ type ServerRaw struct {
 }
 
 type SubscriptionRaw struct {
-	Remarks string      `json:"remarks,omitempty"`
-	Address string      `json:"address"`
-	Status  string      `json:"status"` //update time, error info, etc.
-	Servers []ServerRaw `json:"servers"`
-	Info    string      `json:"info"` // maybe include some info from provider
-	AutoSelect bool     `json:"autoSelect"`
+	DatabaseID             int64          `json:"-"`
+	Remarks                string         `json:"remarks,omitempty"`
+	Address                string         `json:"address"`
+	Status                 string         `json:"status"` //update time, error info, etc.
+	Servers                []ServerRaw    `json:"servers"`
+	Info                   string         `json:"info"` // maybe include some info from provider
+	AutoSelect             bool           `json:"autoSelect"`
+	AutoUpdateMode         AutoUpdateMode `json:"autoUpdateMode"`
+	AutoUpdateIntervalHour int            `json:"autoUpdateIntervalHour"`
+	LastUpdateAttemptAt    string         `json:"lastUpdateAttemptAt,omitempty"`
 }
 
 func Bytes2SubscriptionRaw(b []byte) (*SubscriptionRaw, error) {
@@ -35,6 +39,7 @@ func Bytes2SubscriptionRaw(b []byte) (*SubscriptionRaw, error) {
 	if err := jsoniter.Unmarshal(b, &s); err != nil {
 		return nil, err
 	}
+	s.DatabaseID = gjson.GetBytes(b, "_databaseId").Int()
 	if s.Servers == nil {
 		s.Servers = []ServerRaw{}
 	}

--- a/service/db/configure/raw_test.go
+++ b/service/db/configure/raw_test.go
@@ -1,0 +1,35 @@
+package configure
+
+import (
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/tidwall/gjson"
+)
+
+func TestSubscriptionRawDatabaseIDIsInternal(t *testing.T) {
+	raw, err := Bytes2SubscriptionRaw([]byte(`{
+		"_databaseId": 42,
+		"address": "https://example.invalid/subscription",
+		"status": "",
+		"servers": [],
+		"info": "",
+		"autoSelect": false,
+		"autoUpdateMode": "auto_update_at_intervals",
+		"autoUpdateIntervalHour": 12
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raw.DatabaseID != 42 {
+		t.Fatalf("database ID = %d, want 42", raw.DatabaseID)
+	}
+
+	encoded, err := jsoniter.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gjson.GetBytes(encoded, "_databaseId").Exists() {
+		t.Fatalf("internal database ID leaked into exported JSON: %s", encoded)
+	}
+}

--- a/service/db/listOp.go
+++ b/service/db/listOp.go
@@ -2,12 +2,46 @@ package db
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
-	"strings"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/tidwall/gjson"
 )
+
+type subscriptionListValue struct {
+	DatabaseID             int64             `json:"_databaseId"`
+	Remarks                string            `json:"remarks,omitempty"`
+	Address                string            `json:"address"`
+	Status                 string            `json:"status"`
+	Info                   string            `json:"info"`
+	Servers                []json.RawMessage `json:"servers"`
+	AutoSelect             bool              `json:"autoSelect"`
+	AutoUpdateMode         string            `json:"autoUpdateMode"`
+	AutoUpdateIntervalHour int               `json:"autoUpdateIntervalHour"`
+	LastUpdateAttemptAt    string            `json:"lastUpdateAttemptAt,omitempty"`
+}
+
+func marshalSubscriptionListValue(id int64, remarks, address, status, info string, servers []string,
+	autoSelect bool, autoUpdateMode string, autoUpdateIntervalHour int, lastUpdateAttemptAt string,
+) ([]byte, error) {
+	rawServers := make([]json.RawMessage, len(servers))
+	for i, server := range servers {
+		rawServers[i] = json.RawMessage(server)
+	}
+	return json.Marshal(subscriptionListValue{
+		DatabaseID:             id,
+		Remarks:                remarks,
+		Address:                address,
+		Status:                 status,
+		Info:                   info,
+		Servers:                rawServers,
+		AutoSelect:             autoSelect,
+		AutoUpdateMode:         autoUpdateMode,
+		AutoUpdateIntervalHour: autoUpdateIntervalHour,
+		LastUpdateAttemptAt:    lastUpdateAttemptAt,
+	})
+}
 
 // ListSet sets an element at a specific index in a list.
 func ListSet(bucket string, key string, index int, val interface{}) (err error) {
@@ -53,10 +87,15 @@ func ListSet(bucket string, key string, index int, val interface{}) (err error) 
 		if parsed.Get("autoSelect").Bool() {
 			autoSelect = 1
 		}
+		autoUpdateMode := parsed.Get("autoUpdateMode").String()
+		if autoUpdateMode == "" {
+			autoUpdateMode = "none"
+		}
+		autoUpdateIntervalHour := int(parsed.Get("autoUpdateIntervalHour").Int())
 
 		result, err := db.Exec(
-			"UPDATE subscriptions SET address = ?, remarks = ?, status = ?, info = ?, auto_select = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
-			address, remarks, status, info, autoSelect, subID,
+			"UPDATE subscriptions SET address = ?, remarks = ?, status = ?, info = ?, auto_select = ?, auto_update_mode = ?, auto_update_interval_hour = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+			address, remarks, status, info, autoSelect, autoUpdateMode, autoUpdateIntervalHour, subID,
 		)
 		if err != nil {
 			return err
@@ -96,6 +135,31 @@ func ListSet(bucket string, key string, index int, val interface{}) (err error) 
 	}
 }
 
+// MarkSubscriptionUpdateAttempt records an update attempt regardless of its outcome.
+func MarkSubscriptionUpdateAttempt(databaseID int64) error {
+	result, err := GetDB().Exec(
+		"UPDATE subscriptions SET last_update_attempt_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
+		databaseID,
+	)
+	if err != nil {
+		return err
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("MarkSubscriptionUpdateAttempt: subscription %d not found", databaseID)
+	}
+	return nil
+}
+
+func GetSubscriptionIndexByID(databaseID int64) (int, error) {
+	var index int
+	err := GetDB().QueryRow("SELECT sort FROM subscriptions WHERE id = ?", databaseID).Scan(&index)
+	if err == sql.ErrNoRows {
+		return 0, fmt.Errorf("subscription %d not found", databaseID)
+	}
+	return index, err
+}
+
 // ListGet retrieves an element at a specific index from a list.
 func ListGet(bucket string, key string, index int) (b []byte, err error) {
 	db := GetDB()
@@ -115,46 +179,51 @@ func ListGet(bucket string, key string, index int) (b []byte, err error) {
 		return []byte(configJSON), nil
 
 	case "touch/subscriptions":
-		var address, remarks, status, info string
-		var autoSelectInt int
-		err = db.QueryRow(
-			"SELECT address, remarks, status, info, auto_select FROM subscriptions WHERE sort = ?", index,
-		).Scan(&address, &remarks, &status, &info, &autoSelectInt)
-		if err == sql.ErrNoRows {
-			return nil, fmt.Errorf("ListGet: can't get element from an empty list")
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		// Reconstruct the subscription JSON with servers
-		rows, err := db.Query(
-			"SELECT config_json FROM servers WHERE type = 'subscription_server' AND sub_id = ? ORDER BY sort",
-			int64(index+1),
-		)
-		if err != nil {
-			return nil, err
-		}
-		defer rows.Close()
-
-		var servers []string
-		for rows.Next() {
-			var s string
-			if err := rows.Scan(&s); err != nil {
-				return nil, err
-			}
-			servers = append(servers, s)
-		}
-
-		serversJSON := "[" + strings.Join(servers, ",") + "]"
-		autoSelect := autoSelectInt != 0
-		result := fmt.Sprintf(`{"remarks":"%s","address":"%s","status":"%s","info":"%s","servers":%s,"autoSelect":%v}`,
-			remarks, address, status, info, serversJSON, autoSelect)
-		return []byte(result), nil
+		return listGetSubscription(db, index)
 
 	default:
 		return nil, fmt.Errorf("ListGet: unsupported bucket/key: %s/%s", bucket, key)
 	}
+}
+
+func listGetSubscription(db *sql.DB, index int) ([]byte, error) {
+	var id int64
+	var address, remarks, status, info, autoUpdateMode string
+	var autoSelectInt, autoUpdateIntervalHour int
+	var lastUpdateAttemptAt sql.NullString
+	err := db.QueryRow(
+		"SELECT id, address, remarks, status, info, auto_select, auto_update_mode, auto_update_interval_hour, last_update_attempt_at FROM subscriptions WHERE sort = ?", index,
+	).Scan(&id, &address, &remarks, &status, &info, &autoSelectInt, &autoUpdateMode, &autoUpdateIntervalHour, &lastUpdateAttemptAt)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("ListGet: can't get element from an empty list")
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Reconstruct the subscription JSON with servers
+	rows, err := db.Query(
+		"SELECT config_json FROM servers WHERE type = 'subscription_server' AND sub_id = ? ORDER BY sort",
+		id,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var servers []string
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, err
+		}
+		servers = append(servers, s)
+	}
+	autoSelect := autoSelectInt != 0
+	return marshalSubscriptionListValue(
+		id, remarks, address, status, info, servers, autoSelect,
+		autoUpdateMode, autoUpdateIntervalHour, lastUpdateAttemptAt.String,
+	)
 }
 
 // ListAppend appends values to a list.
@@ -211,14 +280,19 @@ func ListAppend(bucket string, key string, val interface{}) (err error) {
 				if item.Get("autoSelect").Bool() {
 					autoSelect = 1
 				}
+				autoUpdateMode := item.Get("autoUpdateMode").String()
+				if autoUpdateMode == "" {
+					autoUpdateMode = "none"
+				}
+				autoUpdateIntervalHour := int(item.Get("autoUpdateIntervalHour").Int())
 
 				var maxSort int
 				db.QueryRow("SELECT COALESCE(MAX(sort), -1) FROM subscriptions").Scan(&maxSort)
 				newSort := maxSort + 1
 
 				res, err := db.Exec(
-					"INSERT INTO subscriptions (address, remarks, status, info, auto_select, sort) VALUES (?, ?, ?, ?, ?, ?)",
-					address, remarks, status, info, autoSelect, newSort,
+					"INSERT INTO subscriptions (address, remarks, status, info, auto_select, auto_update_mode, auto_update_interval_hour, last_update_attempt_at, sort) VALUES (?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), ?)",
+					address, remarks, status, info, autoSelect, autoUpdateMode, autoUpdateIntervalHour, newSort,
 				)
 				if err != nil {
 					return err
@@ -273,7 +347,7 @@ func ListGetAll(bucket string, key string) (list [][]byte, err error) {
 		return list, rows.Err()
 
 	case "touch/subscriptions":
-		rows, err := db.Query("SELECT id, address, remarks, status, info, auto_select FROM subscriptions ORDER BY sort")
+		rows, err := db.Query("SELECT id, address, remarks, status, info, auto_select, auto_update_mode, auto_update_interval_hour, last_update_attempt_at FROM subscriptions ORDER BY sort")
 		if err != nil {
 			return nil, err
 		}
@@ -281,9 +355,10 @@ func ListGetAll(bucket string, key string) (list [][]byte, err error) {
 
 		for rows.Next() {
 			var id int64
-			var address, remarks, status, info string
-			var autoSelectInt int
-			if err := rows.Scan(&id, &address, &remarks, &status, &info, &autoSelectInt); err != nil {
+			var address, remarks, status, info, autoUpdateMode string
+			var autoSelectInt, autoUpdateIntervalHour int
+			var lastUpdateAttemptAt sql.NullString
+			if err := rows.Scan(&id, &address, &remarks, &status, &info, &autoSelectInt, &autoUpdateMode, &autoUpdateIntervalHour, &lastUpdateAttemptAt); err != nil {
 				return nil, err
 			}
 
@@ -306,11 +381,15 @@ func ListGetAll(bucket string, key string) (list [][]byte, err error) {
 			}
 			serverRows.Close()
 
-			serversJSON := "[" + strings.Join(servers, ",") + "]"
 			autoSelect := autoSelectInt != 0
-			result := fmt.Sprintf(`{"remarks":"%s","address":"%s","status":"%s","info":"%s","servers":%s,"autoSelect":%v}`,
-				remarks, address, status, info, serversJSON, autoSelect)
-			list = append(list, []byte(result))
+			result, err := marshalSubscriptionListValue(
+				id, remarks, address, status, info, servers, autoSelect,
+				autoUpdateMode, autoUpdateIntervalHour, lastUpdateAttemptAt.String,
+			)
+			if err != nil {
+				return nil, err
+			}
+			list = append(list, result)
 		}
 		return list, rows.Err()
 

--- a/service/db/listOp_test.go
+++ b/service/db/listOp_test.go
@@ -1,0 +1,105 @@
+package db
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMarshalSubscriptionListValueEscapesTextAndIncludesDatabaseID(t *testing.T) {
+	encoded, err := marshalSubscriptionListValue(
+		42,
+		"quoted \"remark\"\nnext line",
+		"https://example.invalid/subscription?name=\"test\"",
+		"status\nline",
+		"info\\value",
+		nil,
+		true,
+		"auto_update_at_intervals",
+		12,
+		"2026-08-11T12:00:00Z",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded subscriptionListValue
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if decoded.DatabaseID != 42 || decoded.Remarks != "quoted \"remark\"\nnext line" {
+		t.Fatalf("decoded identity/text = (%d, %q)", decoded.DatabaseID, decoded.Remarks)
+	}
+	if decoded.AutoUpdateMode != "auto_update_at_intervals" || decoded.AutoUpdateIntervalHour != 12 {
+		t.Fatalf("decoded policy = (%q, %d)", decoded.AutoUpdateMode, decoded.AutoUpdateIntervalHour)
+	}
+}
+
+func TestListGetSubscriptionUsesDatabaseIDAfterDeletion(t *testing.T) {
+	database := openSchemaTestDB(t)
+	if err := InitSchema(database); err != nil {
+		t.Fatal(err)
+	}
+
+	firstResult, err := database.Exec(
+		`INSERT INTO subscriptions (address, remarks, sort) VALUES (?, ?, ?)`,
+		"https://example.invalid/first", "first", 0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstID, err := firstResult.LastInsertId()
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondResult, err := database.Exec(
+		`INSERT INTO subscriptions (address, remarks, sort) VALUES (?, ?, ?)`,
+		"https://example.invalid/second", "second", 1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondID, err := secondResult.LastInsertId()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, server := range []struct {
+		subID int64
+		value string
+	}{
+		{firstID, `{"tag":"first-server"}`},
+		{secondID, `{"tag":"second-server"}`},
+	} {
+		if _, err := database.Exec(
+			`INSERT INTO servers (type, sub_id, config_json, sort) VALUES ('subscription_server', ?, ?, 0)`,
+			server.subID, server.value,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := database.Exec(`DELETE FROM servers WHERE sub_id = ?`, firstID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.Exec(`DELETE FROM subscriptions WHERE id = ?`, firstID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.Exec(`UPDATE subscriptions SET sort = 0 WHERE id = ?`, secondID); err != nil {
+		t.Fatal(err)
+	}
+
+	encoded, err := listGetSubscription(database, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded subscriptionListValue
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("invalid subscription JSON: %v", err)
+	}
+	if decoded.DatabaseID != secondID {
+		t.Fatalf("database ID = %d, want %d", decoded.DatabaseID, secondID)
+	}
+	if len(decoded.Servers) != 1 || string(decoded.Servers[0]) != `{"tag":"second-server"}` {
+		t.Fatalf("servers = %s, want second subscription server", encoded)
+	}
+}

--- a/service/db/migrate.go
+++ b/service/db/migrate.go
@@ -75,6 +75,10 @@ func MigrateFromBoltDB() error {
 		_ = tx.Rollback()
 		return fmt.Errorf("failed to migrate touch bucket: %w", err)
 	}
+	if err := migrateLegacySubscriptionUpdatePolicy(tx); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("failed to migrate subscription update policy: %w", err)
+	}
 
 	// NOTE: Accounts are NOT migrated. Users must re-register after migration.
 	// This is intentional: the old MD5-based password hashing is deprecated,

--- a/service/db/schema.go
+++ b/service/db/schema.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/tidwall/gjson"
 	"github.com/v2rayA/v2rayA/pkg/util/log"
 )
 
@@ -39,6 +40,9 @@ CREATE TABLE IF NOT EXISTS subscriptions (
     status TEXT NOT NULL DEFAULT '',
     info TEXT DEFAULT '',
     auto_select INTEGER NOT NULL DEFAULT 0,
+    auto_update_mode TEXT NOT NULL DEFAULT 'none',
+    auto_update_interval_hour INTEGER NOT NULL DEFAULT 0,
+    last_update_attempt_at DATETIME DEFAULT NULL,
     filter TEXT DEFAULT '',
     group_id TEXT DEFAULT '',
     sort INTEGER NOT NULL DEFAULT 0,
@@ -116,5 +120,89 @@ func MigrateSchema(db *sql.DB) error {
 		}
 	}
 
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin subscription update policy migration: %w", err)
+	}
+	defer tx.Rollback()
+
+	policyNeedsBackfill := false
+	err = tx.QueryRow("SELECT COUNT(*) FROM pragma_table_info('subscriptions') WHERE name = 'auto_update_mode'").Scan(&count)
+	if err != nil {
+		return fmt.Errorf("failed to check for auto_update_mode column: %w", err)
+	}
+	if count == 0 {
+		log.Info("Adding auto_update_mode column to subscriptions table")
+		if _, err := tx.Exec("ALTER TABLE subscriptions ADD COLUMN auto_update_mode TEXT NOT NULL DEFAULT 'none'"); err != nil {
+			return fmt.Errorf("failed to add auto_update_mode column: %w", err)
+		}
+		policyNeedsBackfill = true
+	}
+
+	err = tx.QueryRow("SELECT COUNT(*) FROM pragma_table_info('subscriptions') WHERE name = 'auto_update_interval_hour'").Scan(&count)
+	if err != nil {
+		return fmt.Errorf("failed to check for auto_update_interval_hour column: %w", err)
+	}
+	if count == 0 {
+		log.Info("Adding auto_update_interval_hour column to subscriptions table")
+		if _, err := tx.Exec("ALTER TABLE subscriptions ADD COLUMN auto_update_interval_hour INTEGER NOT NULL DEFAULT 0"); err != nil {
+			return fmt.Errorf("failed to add auto_update_interval_hour column: %w", err)
+		}
+		policyNeedsBackfill = true
+	}
+
+	err = tx.QueryRow("SELECT COUNT(*) FROM pragma_table_info('subscriptions') WHERE name = 'last_update_attempt_at'").Scan(&count)
+	if err != nil {
+		return fmt.Errorf("failed to check for last_update_attempt_at column: %w", err)
+	}
+	if count == 0 {
+		log.Info("Adding last_update_attempt_at column to subscriptions table")
+		if _, err := tx.Exec("ALTER TABLE subscriptions ADD COLUMN last_update_attempt_at DATETIME DEFAULT NULL"); err != nil {
+			return fmt.Errorf("failed to add last_update_attempt_at column: %w", err)
+		}
+	}
+
+	if policyNeedsBackfill {
+		if err := migrateLegacySubscriptionUpdatePolicy(tx); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit subscription update policy migration: %w", err)
+	}
+	return nil
+}
+
+func migrateLegacySubscriptionUpdatePolicy(tx *sql.Tx) error {
+	var settingJSON string
+	err := tx.QueryRow("SELECT value FROM system_config WHERE key = 'system:setting'").Scan(&settingJSON)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read legacy subscription update setting: %w", err)
+	}
+
+	mode := gjson.Get(settingJSON, "subscriptionAutoUpdateMode").String()
+	intervalHour := int(gjson.Get(settingJSON, "subscriptionAutoUpdateIntervalHour").Int())
+	switch mode {
+	case "auto_update":
+		intervalHour = 0
+	case "auto_update_at_intervals":
+		if intervalHour < 1 {
+			mode = "none"
+			intervalHour = 0
+		}
+	default:
+		mode = "none"
+		intervalHour = 0
+	}
+	if _, err := tx.Exec(
+		"UPDATE subscriptions SET auto_update_mode = ?, auto_update_interval_hour = ?",
+		mode, intervalHour,
+	); err != nil {
+		return fmt.Errorf("failed to migrate subscription update settings: %w", err)
+	}
 	return nil
 }

--- a/service/db/schema_test.go
+++ b/service/db/schema_test.go
@@ -1,0 +1,174 @@
+package db
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"go.etcd.io/bbolt"
+)
+
+func openSchemaTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	if sqliteDriverName == "" {
+		t.Skip("SQLite driver is unavailable")
+	}
+	database, err := sql.Open(sqliteDriverName, ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	return database
+}
+
+func TestMigrateSchemaCopiesLegacySubscriptionUpdatePolicy(t *testing.T) {
+	database := openSchemaTestDB(t)
+	statements := []string{
+		`CREATE TABLE system_config (key TEXT PRIMARY KEY, value TEXT NOT NULL)`,
+		`CREATE TABLE subscriptions (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			address TEXT NOT NULL DEFAULT '',
+			remarks TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT '',
+			info TEXT DEFAULT '',
+			auto_select INTEGER NOT NULL DEFAULT 0,
+			sort INTEGER NOT NULL DEFAULT 0
+		)`,
+		`INSERT INTO system_config (key, value) VALUES (
+			'system:setting',
+			'{"subscriptionAutoUpdateMode":"auto_update_at_intervals","subscriptionAutoUpdateIntervalHour":12}'
+		)`,
+		`INSERT INTO subscriptions (address) VALUES ('https://example.invalid/subscription')`,
+	}
+	for _, statement := range statements {
+		if _, err := database.Exec(statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := MigrateSchema(database); err != nil {
+		t.Fatal(err)
+	}
+
+	var mode string
+	var intervalHour int
+	var lastAttempt sql.NullString
+	if err := database.QueryRow(
+		`SELECT auto_update_mode, auto_update_interval_hour, last_update_attempt_at FROM subscriptions`,
+	).Scan(&mode, &intervalHour, &lastAttempt); err != nil {
+		t.Fatal(err)
+	}
+	if mode != "auto_update_at_intervals" || intervalHour != 12 {
+		t.Fatalf("migrated policy = (%q, %d), want (%q, %d)", mode, intervalHour, "auto_update_at_intervals", 12)
+	}
+	if lastAttempt.Valid {
+		t.Fatalf("last update attempt = %q, want NULL", lastAttempt.String)
+	}
+
+	if _, err := database.Exec(
+		`UPDATE subscriptions SET auto_update_mode = 'auto_update', auto_update_interval_hour = 0`,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := MigrateSchema(database); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.QueryRow(
+		`SELECT auto_update_mode, auto_update_interval_hour FROM subscriptions`,
+	).Scan(&mode, &intervalHour); err != nil {
+		t.Fatal(err)
+	}
+	if mode != "auto_update" || intervalHour != 0 {
+		t.Fatalf("policy after second migration = (%q, %d), want (%q, %d)", mode, intervalHour, "auto_update", 0)
+	}
+}
+
+func TestSubscriptionUpdatePolicyDefaultsToDisabled(t *testing.T) {
+	database := openSchemaTestDB(t)
+	if err := InitSchema(database); err != nil {
+		t.Fatal(err)
+	}
+	if err := MigrateSchema(database); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.Exec(`INSERT INTO subscriptions (address) VALUES ('https://example.invalid/subscription')`); err != nil {
+		t.Fatal(err)
+	}
+
+	var mode string
+	var intervalHour int
+	if err := database.QueryRow(
+		`SELECT auto_update_mode, auto_update_interval_hour FROM subscriptions`,
+	).Scan(&mode, &intervalHour); err != nil {
+		t.Fatal(err)
+	}
+	if mode != "none" || intervalHour != 0 {
+		t.Fatalf("default policy = (%q, %d), want (%q, %d)", mode, intervalHour, "none", 0)
+	}
+}
+
+func TestBoltMigrationCopiesLegacySubscriptionUpdatePolicy(t *testing.T) {
+	database := openSchemaTestDB(t)
+	if err := InitSchema(database); err != nil {
+		t.Fatal(err)
+	}
+
+	boltDB, err := bbolt.Open(filepath.Join(t.TempDir(), "bolt.db"), 0600, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = boltDB.Close() })
+	if err := boltDB.Update(func(tx *bbolt.Tx) error {
+		system, err := tx.CreateBucket([]byte("system"))
+		if err != nil {
+			return err
+		}
+		if err := system.Put(
+			[]byte("setting"),
+			[]byte(`{"subscriptionAutoUpdateMode":"auto_update_at_intervals","subscriptionAutoUpdateIntervalHour":6}`),
+		); err != nil {
+			return err
+		}
+		touch, err := tx.CreateBucket([]byte("touch"))
+		if err != nil {
+			return err
+		}
+		return touch.Put(
+			[]byte("subscriptions"),
+			[]byte(`[{"address":"https://example.invalid/subscription","servers":[]}]`),
+		)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err := database.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := migrateSystemBucket(boltDB, tx); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if _, err := migrateTouchBucket(boltDB, tx); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := migrateLegacySubscriptionUpdatePolicy(tx); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	var mode string
+	var intervalHour int
+	if err := database.QueryRow(
+		`SELECT auto_update_mode, auto_update_interval_hour FROM subscriptions`,
+	).Scan(&mode, &intervalHour); err != nil {
+		t.Fatal(err)
+	}
+	if mode != "auto_update_at_intervals" || intervalHour != 6 {
+		t.Fatalf("migrated policy = (%q, %d), want (%q, %d)", mode, intervalHour, "auto_update_at_intervals", 6)
+	}
+}

--- a/service/kernel/touch/touch.go
+++ b/service/kernel/touch/touch.go
@@ -28,15 +28,17 @@ type Server struct {
 	PingLatency string              `json:"pingLatency"`
 }
 type Subscription struct {
-	Remarks string              `json:"remarks,omitempty"`
-	ID      int                 `json:"id"`
-	TYPE    configure.TouchType `json:"_type"`
-	Host    string              `json:"host"`
-	Address string              `json:"address"`
-	Status  SubscriptionStatus  `json:"status"`
-	Info    string              `json:"info"`
-	Servers []Server            `json:"servers"`
-	AutoSelect bool             `json:"autoSelect"`
+	Remarks                string                   `json:"remarks,omitempty"`
+	ID                     int                      `json:"id"`
+	TYPE                   configure.TouchType      `json:"_type"`
+	Host                   string                   `json:"host"`
+	Address                string                   `json:"address"`
+	Status                 SubscriptionStatus       `json:"status"`
+	Info                   string                   `json:"info"`
+	Servers                []Server                 `json:"servers"`
+	AutoSelect             bool                     `json:"autoSelect"`
+	AutoUpdateMode         configure.AutoUpdateMode `json:"autoUpdateMode"`
+	AutoUpdateIntervalHour int                      `json:"autoUpdateIntervalHour"`
 }
 
 func NewUpdateStatus() SubscriptionStatus {
@@ -87,14 +89,16 @@ func GenerateTouch() (t Touch) {
 			}
 		}
 		t.Subscriptions[i] = Subscription{
-			Remarks: v.Remarks,
-			ID:      i + 1,
-			Host:    u.Host,
-			Address: v.Address,
-			Status:  SubscriptionStatus(v.Status),
-			Servers: serverRawsToServers(v.Servers),
-			Info:    v.Info,
-			AutoSelect:  v.AutoSelect,
+			Remarks:                v.Remarks,
+			ID:                     i + 1,
+			Host:                   u.Host,
+			Address:                v.Address,
+			Status:                 SubscriptionStatus(v.Status),
+			Servers:                serverRawsToServers(v.Servers),
+			Info:                   v.Info,
+			AutoSelect:             v.AutoSelect,
+			AutoUpdateMode:         v.AutoUpdateMode,
+			AutoUpdateIntervalHour: v.AutoUpdateIntervalHour,
 		}
 	}
 	t.ConnectedServers = configure.GetConnectedServers().Get()

--- a/service/pre_update.go
+++ b/service/pre_update.go
@@ -11,35 +11,70 @@ import (
 	"github.com/v2rayA/v2rayA/server/service"
 )
 
-func updateSubscriptions() {
+const subscriptionUpdateCheckInterval = time.Minute
+
+var subscriptionUpdateMu sync.Mutex
+
+func subscriptionShouldUpdate(sub configure.SubscriptionRaw, now time.Time, serviceStart bool) bool {
+	switch sub.AutoUpdateMode {
+	case configure.AutoUpdate:
+		return serviceStart
+	case configure.AutoUpdateAtIntervals:
+		if sub.AutoUpdateIntervalHour < 1 || sub.LastUpdateAttemptAt == "" {
+			return sub.AutoUpdateIntervalHour >= 1
+		}
+		lastAttempt, err := time.Parse(time.RFC3339, sub.LastUpdateAttemptAt)
+		if err != nil {
+			return true
+		}
+		return !now.Before(lastAttempt.Add(time.Duration(sub.AutoUpdateIntervalHour) * time.Hour))
+	default:
+		return false
+	}
+}
+
+func updateSubscriptions(serviceStart bool) {
+	subscriptionUpdateMu.Lock()
+	defer subscriptionUpdateMu.Unlock()
+
 	subs := configure.GetSubscriptions()
-	lenSubs := len(subs)
+	databaseIDs := make([]int64, 0, len(subs))
+	now := time.Now()
+	for _, sub := range subs {
+		if subscriptionShouldUpdate(sub, now, serviceStart) {
+			databaseIDs = append(databaseIDs, sub.DatabaseID)
+		}
+	}
+	if len(databaseIDs) == 0 {
+		return
+	}
+
 	control := make(chan struct{}, 2) // concurrency limit: update 2 subscriptions at a time
 	// Disconnect from subscriptions before auto-selecting servers from them
 	// to limit the number of connected servers and avoid hitting the limit
 	shouldDisconnect := true
-	err := service.AutoSelectServersFromSubscriptions(shouldDisconnect)
+	err := service.AutoSelectServersFromSubscriptionIDs(databaseIDs, shouldDisconnect)
 	if err != nil {
 		log.Error("[AutoSelect] Failed to disconnect servers from subscriptions -- err: %v", err)
 	}
 	wg := new(sync.WaitGroup)
-	for i := 0; i < lenSubs; i++ {
+	for _, databaseID := range databaseIDs {
 		wg.Add(1)
-		go func(i int) {
+		go func(databaseID int64) {
 			control <- struct{}{}
-			err := service.UpdateSubscription(i, false)
+			err := service.UpdateSubscriptionByID(databaseID, false)
 			if err != nil {
-				log.Info("[AutoUpdate] Subscriptions: Failed to update subscription -- ID: %d, err: %v", i, err)
+				log.Info("[AutoUpdate] Subscriptions: Failed to update subscription -- ID: %d, err: %v", databaseID, err)
 			} else {
-				log.Info("[AutoUpdate] Subscriptions: Complete updating subscription -- ID: %d, Address: %s", i, subs[i].Address)
+				log.Info("[AutoUpdate] Subscriptions: Complete updating subscription -- ID: %d", databaseID)
 			}
 			wg.Done()
 			<-control
-		}(i)
+		}(databaseID)
 	}
 	wg.Wait()
 	shouldDisconnect = false
-	err2 := service.AutoSelectServersFromSubscriptions(shouldDisconnect)
+	err2 := service.AutoSelectServersFromSubscriptionIDs(databaseIDs, shouldDisconnect)
 	if err2 != nil {
 		log.Error("[AutoSelect] Failed to auto-select servers from subscriptions -- err: %v", err2)
 	}
@@ -48,7 +83,7 @@ func updateSubscriptions() {
 
 func initUpdatingTicker() {
 	conf.TickerUpdateGFWList = time.NewTicker(24 * time.Hour * 365 * 100)
-	conf.TickerUpdateSubscription = time.NewTicker(24 * time.Hour * 365 * 100)
+	conf.TickerUpdateSubscription = time.NewTicker(subscriptionUpdateCheckInterval)
 	go func() {
 		for range conf.TickerUpdateGFWList.C {
 			_, err := dat.CheckAndUpdateGFWList("")
@@ -59,7 +94,7 @@ func initUpdatingTicker() {
 	}()
 	go func() {
 		for range conf.TickerUpdateSubscription.C {
-			updateSubscriptions()
+			updateSubscriptions(false)
 		}
 	}()
 }
@@ -93,15 +128,7 @@ func checkUpdate() {
 		}
 	}
 
-	// check for subscription updates
-	if setting.SubscriptionAutoUpdateMode == configure.AutoUpdate ||
-		setting.SubscriptionAutoUpdateMode == configure.AutoUpdateAtIntervals {
-
-		if setting.SubscriptionAutoUpdateMode == configure.AutoUpdateAtIntervals {
-			conf.TickerUpdateSubscription.Reset(time.Duration(setting.SubscriptionAutoUpdateIntervalHour) * time.Hour)
-		}
-		go updateSubscriptions()
-	}
+	go updateSubscriptions(true)
 	// check for server updates
 	go func() {
 		f := func() {

--- a/service/pre_update_test.go
+++ b/service/pre_update_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/v2rayA/v2rayA/db/configure"
+)
+
+func TestSubscriptionShouldUpdate(t *testing.T) {
+	now := time.Date(2026, time.August, 11, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name         string
+		subscription configure.SubscriptionRaw
+		serviceStart bool
+		want         bool
+	}{
+		{
+			name:         "disabled",
+			subscription: configure.SubscriptionRaw{AutoUpdateMode: configure.NotAutoUpdate},
+			serviceStart: true,
+		},
+		{
+			name:         "start mode on service start",
+			subscription: configure.SubscriptionRaw{AutoUpdateMode: configure.AutoUpdate},
+			serviceStart: true,
+			want:         true,
+		},
+		{
+			name:         "start mode on periodic check",
+			subscription: configure.SubscriptionRaw{AutoUpdateMode: configure.AutoUpdate},
+		},
+		{
+			name: "interval without previous attempt",
+			subscription: configure.SubscriptionRaw{
+				AutoUpdateMode:         configure.AutoUpdateAtIntervals,
+				AutoUpdateIntervalHour: 12,
+			},
+			want: true,
+		},
+		{
+			name: "invalid interval",
+			subscription: configure.SubscriptionRaw{
+				AutoUpdateMode: configure.AutoUpdateAtIntervals,
+			},
+		},
+		{
+			name: "interval not due",
+			subscription: configure.SubscriptionRaw{
+				AutoUpdateMode:         configure.AutoUpdateAtIntervals,
+				AutoUpdateIntervalHour: 12,
+				LastUpdateAttemptAt:    now.Add(-11 * time.Hour).Format(time.RFC3339),
+			},
+		},
+		{
+			name: "interval due",
+			subscription: configure.SubscriptionRaw{
+				AutoUpdateMode:         configure.AutoUpdateAtIntervals,
+				AutoUpdateIntervalHour: 12,
+				LastUpdateAttemptAt:    now.Add(-12 * time.Hour).Format(time.RFC3339),
+			},
+			want: true,
+		},
+		{
+			name: "invalid previous attempt is due",
+			subscription: configure.SubscriptionRaw{
+				AutoUpdateMode:         configure.AutoUpdateAtIntervals,
+				AutoUpdateIntervalHour: 12,
+				LastUpdateAttemptAt:    "invalid",
+			},
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := subscriptionShouldUpdate(test.subscription, now, test.serviceStart); got != test.want {
+				t.Fatalf("subscriptionShouldUpdate() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/service/server/service/setting.go
+++ b/service/server/service/setting.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"github.com/v2rayA/v2rayA/conf"
+	"github.com/v2rayA/v2rayA/db/configure"
 	"github.com/v2rayA/v2rayA/kernel/ipforward"
 	"github.com/v2rayA/v2rayA/kernel/v2ray"
 	"github.com/v2rayA/v2rayA/kernel/v2ray/asset"
-	"github.com/v2rayA/v2rayA/db/configure"
 	"github.com/v2rayA/v2rayA/pkg/util/log"
 )
 
@@ -54,11 +54,6 @@ func UpdateSetting(setting *configure.Setting) (err error) {
 		conf.TickerUpdateGFWList.Reset(time.Duration(setting.GFWListAutoUpdateIntervalHour) * time.Hour)
 	} else {
 		conf.TickerUpdateGFWList.Reset(24 * time.Hour * 365 * 100)
-	}
-	if setting.SubscriptionAutoUpdateMode == configure.AutoUpdateAtIntervals {
-		conf.TickerUpdateSubscription.Reset(time.Duration(setting.SubscriptionAutoUpdateIntervalHour) * time.Hour)
-	} else {
-		conf.TickerUpdateSubscription.Reset(24 * time.Hour * 365 * 100)
 	}
 	return
 }

--- a/service/server/service/subscription.go
+++ b/service/server/service/subscription.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -210,9 +211,59 @@ func getDataUsageStatus(bytesUsed, bytesRemaining uint64) (status string) {
 	return
 }
 
-func UpdateSubscription(index int, disconnectIfNecessary bool) (err error) {
-	subscriptions := configure.GetSubscriptions()
-	addr := subscriptions[index].Address
+var subscriptionMutationMu sync.Mutex
+var updatingSubscriptionIDs = make(map[int64]struct{})
+
+func beginSubscriptionUpdate(subscription *configure.SubscriptionRaw) error {
+	if subscription == nil || subscription.DatabaseID == 0 {
+		return fmt.Errorf("UpdateSubscription: subscription not found")
+	}
+	if _, updating := updatingSubscriptionIDs[subscription.DatabaseID]; updating {
+		return fmt.Errorf("UpdateSubscription: subscription is already updating")
+	}
+	if err := configure.MarkSubscriptionUpdateAttempt(subscription.DatabaseID); err != nil {
+		return fmt.Errorf("UpdateSubscription: failed to record update attempt: %w", err)
+	}
+	updatingSubscriptionIDs[subscription.DatabaseID] = struct{}{}
+	return nil
+}
+
+func finishSubscriptionUpdate(databaseID int64) {
+	subscriptionMutationMu.Lock()
+	delete(updatingSubscriptionIDs, databaseID)
+	subscriptionMutationMu.Unlock()
+}
+
+func UpdateSubscription(index int, disconnectIfNecessary bool) error {
+	subscriptionMutationMu.Lock()
+	subscription := configure.GetSubscription(index)
+	err := beginSubscriptionUpdate(subscription)
+	subscriptionMutationMu.Unlock()
+	if err != nil {
+		return err
+	}
+	defer finishSubscriptionUpdate(subscription.DatabaseID)
+	return updateSubscription(subscription.DatabaseID, subscription.Address, disconnectIfNecessary)
+}
+
+func UpdateSubscriptionByID(databaseID int64, disconnectIfNecessary bool) error {
+	subscriptionMutationMu.Lock()
+	index, err := configure.GetSubscriptionIndexByID(databaseID)
+	if err != nil {
+		subscriptionMutationMu.Unlock()
+		return fmt.Errorf("UpdateSubscription: %w", err)
+	}
+	subscription := configure.GetSubscription(index)
+	err = beginSubscriptionUpdate(subscription)
+	subscriptionMutationMu.Unlock()
+	if err != nil {
+		return err
+	}
+	defer finishSubscriptionUpdate(databaseID)
+	return updateSubscription(databaseID, subscription.Address, disconnectIfNecessary)
+}
+
+func updateSubscription(databaseID int64, addr string, disconnectIfNecessary bool) (err error) {
 	c := httpClient.GetHttpClientAutomatically()
 	resolv.CheckResolvConf()
 	subscriptionInfos, status, err := ResolveSubscriptionWithClient(addr, c)
@@ -221,6 +272,21 @@ func UpdateSubscription(index int, disconnectIfNecessary bool) (err error) {
 		log.Warn("UpdateSubscription: %v: %v", err, subscriptionInfos)
 		return fmt.Errorf("UpdateSubscription: %v", reason)
 	}
+
+	subscriptionMutationMu.Lock()
+	defer subscriptionMutationMu.Unlock()
+	index, err := configure.GetSubscriptionIndexByID(databaseID)
+	if err != nil {
+		return fmt.Errorf("UpdateSubscription: %w", err)
+	}
+	subscription := configure.GetSubscription(index)
+	if subscription == nil {
+		return fmt.Errorf("UpdateSubscription: subscription %d not found", databaseID)
+	}
+	if subscription.Address != addr {
+		return fmt.Errorf("UpdateSubscription: subscription address changed during update")
+	}
+
 	infoServerRaws := make([]configure.ServerRaw, len(subscriptionInfos))
 	css := configure.GetConnectedServers()
 	cssAfter := css.Get()
@@ -326,10 +392,10 @@ func UpdateSubscription(index int, disconnectIfNecessary bool) (err error) {
 	if err := configure.OverwriteConnects(configure.NewWhiches(cssAfter)); err != nil {
 		return err
 	}
-	subscriptions[index].Servers = infoServerRaws
-	subscriptions[index].Status = string(touch.NewUpdateStatus())
-	subscriptions[index].Info = status
-	if err := configure.SetSubscription(index, &subscriptions[index]); err != nil {
+	subscription.Servers = infoServerRaws
+	subscription.Status = string(touch.NewUpdateStatus())
+	subscription.Info = status
+	if err := configure.SetSubscription(index, subscription); err != nil {
 		return err
 	}
 	// A remapped connection may point at a server whose config differs from the old
@@ -343,13 +409,32 @@ func UpdateSubscription(index int, disconnectIfNecessary bool) (err error) {
 }
 
 func ModifySubscriptionRemark(subscription touch.Subscription) (err error) {
+	subscriptionMutationMu.Lock()
+	defer subscriptionMutationMu.Unlock()
+
 	raw := configure.GetSubscription(subscription.ID - 1)
 	if raw == nil {
 		return fmt.Errorf("failed to find the corresponding subscription")
 	}
+	if subscription.AutoUpdateMode == "" {
+		subscription.AutoUpdateMode = raw.AutoUpdateMode
+		subscription.AutoUpdateIntervalHour = raw.AutoUpdateIntervalHour
+	}
+	switch subscription.AutoUpdateMode {
+	case configure.NotAutoUpdate, configure.AutoUpdate:
+		subscription.AutoUpdateIntervalHour = 0
+	case configure.AutoUpdateAtIntervals:
+		if subscription.AutoUpdateIntervalHour < 1 {
+			return fmt.Errorf("subscription update interval must be at least 1 hour")
+		}
+	default:
+		return fmt.Errorf("invalid subscription auto-update mode")
+	}
 	raw.Remarks = subscription.Remarks
 	raw.Address = subscription.Address
 	raw.AutoSelect = subscription.AutoSelect
+	raw.AutoUpdateMode = subscription.AutoUpdateMode
+	raw.AutoUpdateIntervalHour = subscription.AutoUpdateIntervalHour
 	return configure.SetSubscription(subscription.ID-1, raw)
 }
 
@@ -423,6 +508,27 @@ func AutoSelectServersFromSubscriptions(shouldDisconnect bool) (err error) {
 					return err
 				}
 			}
+		}
+	}
+	return nil
+}
+
+func AutoSelectServersFromSubscriptionIDs(databaseIDs []int64, shouldDisconnect bool) error {
+	subscriptionMutationMu.Lock()
+	defer subscriptionMutationMu.Unlock()
+
+	for _, databaseID := range databaseIDs {
+		index, err := configure.GetSubscriptionIndexByID(databaseID)
+		if err != nil {
+			log.Warn("[AutoSelect] Failed to find subscription %d, skipping", databaseID)
+			continue
+		}
+		subscription := configure.GetSubscription(index)
+		if subscription == nil || !subscription.AutoSelect {
+			continue
+		}
+		if err := SelectServersFromSubscription(index, shouldDisconnect); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/service/server/service/subscription.go
+++ b/service/server/service/subscription.go
@@ -513,6 +513,29 @@ func AutoSelectServersFromSubscriptions(shouldDisconnect bool) (err error) {
 	return nil
 }
 
+func connectedSubscriptionServers(index int, connected *configure.Whiches) []*configure.Which {
+	if connected == nil {
+		return nil
+	}
+	servers := make([]*configure.Which, 0)
+	for _, which := range connected.Get() {
+		if which != nil && which.TYPE == configure.SubscriptionServerType && which.Sub == index {
+			servers = append(servers, which)
+		}
+	}
+	return servers
+}
+
+func disconnectSubscriptionServers(index int) error {
+	connected := configure.GetConnectedServersByOutbound("proxy")
+	for _, which := range connectedSubscriptionServers(index, connected) {
+		if err := Disconnect(*which, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func AutoSelectServersFromSubscriptionIDs(databaseIDs []int64, shouldDisconnect bool) error {
 	subscriptionMutationMu.Lock()
 	defer subscriptionMutationMu.Unlock()
@@ -527,7 +550,14 @@ func AutoSelectServersFromSubscriptionIDs(databaseIDs []int64, shouldDisconnect 
 		if subscription == nil || !subscription.AutoSelect {
 			continue
 		}
-		if err := SelectServersFromSubscription(index, shouldDisconnect); err != nil {
+		if shouldDisconnect {
+			// Only remove this source's connections. The legacy helper clears
+			// the whole proxy outbound, which would disconnect other sources.
+			err = disconnectSubscriptionServers(index)
+		} else {
+			err = SelectServersFromSubscription(index, false)
+		}
+		if err != nil {
 			return err
 		}
 	}

--- a/service/server/service/subscription_test.go
+++ b/service/server/service/subscription_test.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/v2rayA/v2rayA/db/configure"
+)
+
+func TestConnectedSubscriptionServersOnlyTargetsOneSource(t *testing.T) {
+	connected := &configure.Whiches{Touches: []*configure.Which{
+		{TYPE: configure.SubscriptionServerType, ID: 1, Sub: 0, Outbound: "proxy"},
+		{TYPE: configure.SubscriptionServerType, ID: 2, Sub: 0, Outbound: "proxy"},
+		{TYPE: configure.SubscriptionServerType, ID: 1, Sub: 1, Outbound: "proxy"},
+		{TYPE: configure.ServerType, ID: 1, Outbound: "proxy"},
+	}}
+
+	got := connectedSubscriptionServers(0, connected)
+	if len(got) != 2 {
+		t.Fatalf("matched connections = %d, want 2", len(got))
+	}
+	for _, which := range got {
+		if which.Sub != 0 || which.TYPE != configure.SubscriptionServerType {
+			t.Fatalf("matched unexpected connection: %+v", which)
+		}
+	}
+}
+
+func TestConnectedSubscriptionServersHandlesNil(t *testing.T) {
+	if got := connectedSubscriptionServers(0, nil); got != nil {
+		t.Fatalf("matched connections = %+v, want nil", got)
+	}
+}

--- a/service/server/service/touch.go
+++ b/service/server/service/touch.go
@@ -5,6 +5,9 @@ import (
 )
 
 func DeleteWhich(ws []*configure.Which) (err error) {
+	subscriptionMutationMu.Lock()
+	defer subscriptionMutationMu.Unlock()
+
 	var data *configure.Whiches
 	// Deduplicate touches to delete
 	data = configure.NewWhiches(ws)


### PR DESCRIPTION
## Why this branch exists

Some subscription providers issue short-lived subscription URLs. SSSDOG subscription URLs are valid for only about five minutes. The existing global update timer can run after such a URL has expired. That update can then fail and leave the subscription source with all of its nodes unusable. In practice, one expired update attempt can make the whole source appear invalid.

Different providers have different URL lifetimes and update requirements, so a single global schedule cannot be safe for every source. Short-lived sources such as SSSDOG need to be able to disable automatic updates, while normal sources should keep their own update schedule.

## Design

1. Each subscription stores one of three policies: `none`, `auto_update` (update on service start), or `auto_update_at_intervals` (update at its own interval).
2. The policy, interval, and `last_update_attempt_at` are persisted with the subscription. The scheduler checks due sources every minute and updates only those sources.
3. Updates use the subscription's persistent database ID rather than its position in the sorted list. This avoids targeting the wrong source after a deletion creates a sort/index gap.
4. The update path records an attempt before requesting the URL, prevents concurrent updates of the same source, and re-resolves the current position by database ID before writing results.
5. Before refreshing due sources, only their own selected connections are removed. Other subscription sources and manual connections remain active; the legacy full auto-select path is unchanged.
6. Existing global settings are copied to every existing subscription during schema/BoltDB migration. This is a field migration only; it does not upgrade the SQLite engine or database version.

## Files changed

### User interface

- `gui/src/components/modalSetting.vue`: remove the global subscription auto-update controls and their global validation/time handling.
- `gui/src/components/modalSubcription.vue`: add per-source mode and interval controls, validation, and reset of the interval when automatic updates are disabled.

### Persistence and compatibility

- `service/db/schema.go`: add per-subscription columns and migrate/backfill the legacy global policy.
- `service/db/migrate.go`: apply the same policy backfill during BoltDB migration.
- `service/db/listOp.go`: read/write the new fields, persist update attempts, expose the internal database ID, and reconstruct subscription JSON safely after deletions.
- `service/db/configure/raw.go`: add the internal database ID and per-source policy fields to `SubscriptionRaw`.
- `service/db/configure/configure.go`: expose database-ID lookup and update-attempt operations to the service layer.

### Scheduler, update flow, and API data

- `service/pre_update.go`: replace the global subscription timer behavior with a minute-level due check and per-source updates on startup/interval ticks.
- `service/server/service/subscription.go`: update by persistent ID, validate per-source policy, serialize mutation access, select only due-source connections, and preserve unrelated connections during refresh.
- `service/server/service/setting.go`: remove global subscription-timer resets from global setting updates.
- `service/server/service/touch.go`: serialize subscription deletion with update mutations.
- `service/kernel/touch/touch.go`: expose each source's update mode and interval through the touch/API model.

### Tests

- `service/db/configure/raw_test.go`: verify the internal database ID is parsed but not exported.
- `service/db/listOp_test.go`: verify JSON escaping and stable source/server lookup after deletion.
- `service/db/schema_test.go`: verify new-schema defaults and legacy schema/BoltDB policy migration.
- `service/pre_update_test.go`: verify startup, interval, disabled, and invalid-policy decisions.
- `service/server/service/subscription_test.go`: verify selective connection removal targets only the due source.

## Validation

- `npm.cmd run build`
- `go test -count=1 ./db ./db/configure . ./server/service`
- `git diff --check`

The focused tests and production web build pass. Repository-wide tests/lint still have pre-existing environment blockers unrelated to this change.