### PR TITLE
fix: preserve core state across graceful restarts

### DIFF
--- a/service/kernel/v2ray/process.go
+++ b/service/kernel/v2ray/process.go
@@ -11,16 +11,17 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
 	"github.com/shirou/gopsutil/v3/mem"
 	"github.com/v2rayA/v2rayA/common"
 	"github.com/v2rayA/v2rayA/conf"
+	"github.com/v2rayA/v2rayA/db/configure"
 	"github.com/v2rayA/v2rayA/kernel/serverObj"
 	"github.com/v2rayA/v2rayA/kernel/v2ray/asset"
 	"github.com/v2rayA/v2rayA/kernel/v2ray/where"
-	"github.com/v2rayA/v2rayA/db/configure"
 	"github.com/v2rayA/v2rayA/pkg/util/log"
 )
 
@@ -35,6 +36,7 @@ type Process struct {
 	template       *Template
 	tag2WhichIndex map[string]int
 	done           chan struct{}
+	expectedStop   atomic.Bool
 }
 
 func NewProcess(tmpl *Template,
@@ -105,7 +107,7 @@ func NewProcess(tmpl *Template,
 	go func() {
 		defer close(process.done)
 		p, e := proc.Wait()
-		if process.procCancel == nil {
+		if process.expectedStop.Load() {
 			// canceled by v2rayA
 			return
 		}
@@ -188,8 +190,10 @@ func (p *Process) Close() error {
 	defer p.mutex.Unlock()
 	// 停止 xray 进程（v2raya-core 内部会同时关闭 DNS 模块）
 	if p.procCancel != nil {
-		p.procCancel()
+		cancel := p.procCancel
+		p.expectedStop.Store(true)
 		p.procCancel = nil
+		cancel()
 		err := p.template.Close()
 		if err != nil {
 			return err

--- a/service/kernel/v2ray/process_test.go
+++ b/service/kernel/v2ray/process_test.go
@@ -1,0 +1,19 @@
+package v2ray
+
+import "testing"
+
+func TestProcessCloseMarksExpectedStopBeforeCancel(t *testing.T) {
+	process := &Process{template: &Template{}}
+	process.procCancel = func() {
+		if !process.expectedStop.Load() {
+			t.Fatal("expected stop must be recorded before canceling the core")
+		}
+	}
+
+	if err := process.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if !process.expectedStop.Load() {
+		t.Fatal("Close() did not record the expected stop")
+	}
+}


### PR DESCRIPTION
This PR prevents graceful v2rayA or Windows shutdowns from being misclassified as v2ray-core crashes, so a previously running core can be restored on the next service start.

## Problem

After a Windows restart, the v2rayA management service could come back normally while the proxy core stayed stopped. The web UI remained reachable on port `2017`, but the HTTP/SOCKS inbound ports were no longer listening. The version API reported `lastKernelExit: "crashed"`, so the existing startup protection intentionally refused to restore the core.

This breaks the intended state-preserving behavior:

- if the core was running before a graceful shutdown, it should run again after v2rayA starts;
- if the user explicitly stopped the core, it should remain stopped;
- if the core actually crashed, it should remain stopped so the failure can be inspected.

## Why it happens

`Process.Close` used `procCancel == nil` as the signal that a core exit was expected:

1. call `procCancel()`;
2. set `procCancel = nil`;
3. the wait goroutine returns from `proc.Wait()` and checks `procCancel`.

Canceling the process can wake the wait goroutine before step 2 runs. In that window, the goroutine still sees a non-nil cancel function and invokes `postUnexpectedStop`. `CoreProcessManager.handleUnexpectedStop` then clears the running flag and records `LastKernelExitCrashed`.

The same field was therefore being used both as a function and as an unsynchronized lifecycle flag. The ordering also allowed a normal service shutdown to be recorded as a crash.

## How the cause was found

The investigation followed the failure from the network symptom back to the process lifecycle:

1. Confirmed that the machine's LAN address had not changed.
2. Confirmed that port `2017` was listening while the proxy inbound port was not.
3. Confirmed that the generated config still contained the LAN inbound and that the firewall allow rules were present.
4. Confirmed that `v2raya.exe` was running but `v2raya_core.exe` was absent.
5. Correlated the service log with the Windows boot time: v2rayA exited with code `0`, the DNS module logged a normal stop, and the next startup warned that the core had exited abnormally.
6. Confirmed through `/api/version` that `lastKernelExit` was `crashed`.
7. Traced that state through `pre_run.go`, `handleUnexpectedStop`, the wait goroutine, and `Process.Close`, which exposed the cancel-before-marker race.

## Solution design

The fix keeps the existing three-state behavior and changes only how an expected stop is communicated:

- add an `atomic.Bool` named `expectedStop` to `Process`;
- store `true` before canceling the core context;
- have the wait goroutine read the atomic flag instead of reading `procCancel` concurrently;
- leave unexpected exits on the existing `postUnexpectedStop` path.

This does not force the core to start on every service launch. It only preserves the existing running state across graceful shutdowns while retaining crash protection and explicit-stop behavior.

## Implementation

- `service/kernel/v2ray/process.go`
  - records an expected stop before cancellation;
  - uses an atomic load in the wait goroutine;
  - removes the unsynchronized lifecycle read of `procCancel`.
- `service/kernel/v2ray/process_test.go`
  - verifies that the expected-stop marker is visible before the cancel callback executes;
  - verifies that `Close` leaves the process marked as an expected stop.

## Test process

The change was tested from a clean worktree based on the current upstream `main` branch.

1. Format and patch validation:
   - `gofmt` on both changed files
   - `git diff --check`
2. Focused package test:
   - `go test -count=1 ./kernel/v2ray`
3. Repeated regression test:
   - `go test -count=100 -run TestProcessCloseMarksExpectedStopBeforeCancel ./kernel/v2ray`
4. Related package compilation/tests:
   - `go test -count=1 . ./db ./db/configure ./server/service`
5. Static analysis:
   - `go vet ./kernel/v2ray`

An attempted local `go test -race` run was not counted as validation because the Windows Go environment had CGO disabled and the race detector requires CGO.

## Test results

- Focused `kernel/v2ray` test: passed.
- Regression test repeated 100 times: passed.
- Main, database, configuration, and service packages: compiled/tested successfully.
- `go vet`: passed.
- `git diff --check`: passed.

The final diff contains one implementation file and one regression-test file only.
