### PR TITLE
fix: reduce GeoIP parser memory usage

### DIFF
--- a/service/common/parseGeoIP/parser.go
+++ b/service/common/parseGeoIP/parser.go
@@ -5,31 +5,91 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/v2rayA/v2rayA/kernel/v2ray/asset"
+	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 )
 
-func Parser(filename string, countryCode string) ([]string, []string, error) {
-	var ipv4List []string
-	var ipv6List []string
-	var geoIpProto GeoIPList
+type parserResult struct {
+	ipv4 []string
+	ipv6 []string
+}
 
+type parserCacheKey struct {
+	path        string
+	size        int64
+	modTime     int64
+	countryCode string
+}
+
+var parserCache sync.Map
+
+func Parser(filename string, countryCode string) ([]string, []string, error) {
 	realpath, err := asset.GetV2rayLocationAsset(filename)
 	if err != nil {
-		return ipv4List, ipv6List, err
+		return nil, nil, err
 	}
+	info, err := os.Stat(realpath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cacheKey := parserCacheKey{
+		path:        realpath,
+		size:        info.Size(),
+		modTime:     info.ModTime().UnixNano(),
+		countryCode: countryCode,
+	}
+	if cached, ok := parserCache.Load(cacheKey); ok {
+		result := cached.(parserResult)
+		return result.ipv4, result.ipv6, nil
+	}
+
 	data, err := os.ReadFile(realpath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ipv4List, ipv6List, err := parseGeoIP(data, countryCode)
 	if err != nil {
 		return ipv4List, ipv6List, err
 	}
 
-	if err := proto.Unmarshal(data, &geoIpProto); err != nil {
-		return ipv4List, ipv6List, err
-	}
+	parserCache.Store(cacheKey, parserResult{ipv4: ipv4List, ipv6: ipv6List})
+	return ipv4List, ipv6List, nil
+}
 
-	for _, geo := range geoIpProto.Entry {
-		if geo.CountryCode == countryCode {
+func parseGeoIP(data []byte, countryCode string) ([]string, []string, error) {
+	var ipv4List []string
+	var ipv6List []string
+
+	// GeoIPList contains repeated GeoIP messages in field 1. Decoding the
+	// complete list expands a roughly 22 MiB asset to hundreds of MiB in
+	// memory. Decode one entry at a time and stop at the requested country.
+	for len(data) > 0 {
+		number, wireType, n := protowire.ConsumeTag(data)
+		if n < 0 {
+			return ipv4List, ipv6List, protowire.ParseError(n)
+		}
+		data = data[n:]
+
+		if number == 1 && wireType == protowire.BytesType {
+			entryData, consumed := protowire.ConsumeBytes(data)
+			if consumed < 0 {
+				return ipv4List, ipv6List, protowire.ParseError(consumed)
+			}
+			data = data[consumed:]
+
+			var geo GeoIP
+			if err := proto.Unmarshal(entryData, &geo); err != nil {
+				return ipv4List, ipv6List, err
+			}
+			if geo.CountryCode != countryCode {
+				continue
+			}
+
 			for _, c := range geo.Cidr {
 				ip := net.IP(c.Ip)
 				if strings.Contains(ip.String(), ":") {
@@ -42,8 +102,15 @@ func Parser(filename string, countryCode string) ([]string, []string, error) {
 					ipv4List = append(ipv4List, fmt.Sprintf("%s/%d", ip.String(), c.Prefix))
 				}
 			}
-			break
+			return ipv4List, ipv6List, nil
 		}
+
+		consumed := protowire.ConsumeFieldValue(number, wireType, data)
+		if consumed < 0 {
+			return ipv4List, ipv6List, protowire.ParseError(consumed)
+		}
+		data = data[consumed:]
 	}
+
 	return ipv4List, ipv6List, nil
 }

--- a/service/common/parseGeoIP/parser_test.go
+++ b/service/common/parseGeoIP/parser_test.go
@@ -1,0 +1,51 @@
+package parseGeoIP
+
+import (
+	"net"
+	"reflect"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+)
+
+func TestParseGeoIPStopsAtRequestedEntry(t *testing.T) {
+	data, err := proto.Marshal(&GeoIPList{Entry: []*GeoIP{
+		{
+			CountryCode: "PRIVATE",
+			Cidr: []*CIDR{
+				{Ip: net.ParseIP("10.0.0.0").To4(), Prefix: 8},
+				{Ip: net.ParseIP("198.18.0.0").To4(), Prefix: 15},
+				{Ip: net.ParseIP("2001:db8::"), Prefix: 32},
+			},
+		},
+		{
+			CountryCode: "US",
+			Cidr: []*CIDR{
+				{Ip: net.ParseIP("192.0.2.0").To4(), Prefix: 24},
+			},
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A malformed record after the requested entry must not be decoded.
+	data = append(data, 0x0a, 0x02, 0xff)
+
+	ipv4, ipv6, err := parseGeoIP(data, "PRIVATE")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"10.0.0.0/8"}; !reflect.DeepEqual(ipv4, want) {
+		t.Fatalf("IPv4 entries = %v, want %v", ipv4, want)
+	}
+	if want := []string{"2001:db8::/32"}; !reflect.DeepEqual(ipv6, want) {
+		t.Fatalf("IPv6 entries = %v, want %v", ipv6, want)
+	}
+}
+
+func TestParseGeoIPRejectsMalformedData(t *testing.T) {
+	if _, _, err := parseGeoIP([]byte{0x0a, 0x02, 0xff}, "PRIVATE"); err == nil {
+		t.Fatal("parseGeoIP() accepted malformed data")
+	}
+}


### PR DESCRIPTION
## Summary

- decode top-level GeoIP entries incrementally with `protowire` and stop at the requested country
- cache successful results by asset path, size, modification time, and country code
- add tests for early exit, IPv4/IPv6 output, fake-IP filtering, and malformed data

## Root cause

`Parser` currently reads `geoip.dat` and unmarshals the complete `GeoIPList` on every call. Transparent-proxy rule generation calls the parser several times even when only the `PRIVATE` entry is requested. On memory-constrained routers, decoding the complete protobuf repeatedly can trigger the global OOM killer.

## Impact

On a 512 MiB aarch64 OpenWrt router with a 23,080,744-byte `geoip.dat`, the existing parser reached about 355 MiB RSS and was killed by OOM. With the equivalent patch built against v2rayA 2.2.7.5:

- TProxy initialization completed in about 2-3 seconds
- v2rayA remained stable at about 100 MiB RSS
- Xray remained around 24 MiB RSS
- more than 270 MiB remained available
- no additional OOM event occurred

## Validation

- device-tested on OpenWrt SNAPSHOT r35820-964c05aee9, MediaTek Filogic/aarch64
- added focused parser unit tests
- unit tests were not run in this workspace because a Go 1.26 toolchain was unavailable

## Tracking

- v2rayA discussion: https://github.com/v2rayA/v2rayA/discussions/1932
- OpenWrt package issue: https://github.com/openwrt/packages/issues/30285

The orphaned Xray child-process behavior reported in those threads is a separate lifecycle issue and is intentionally not changed by this PR.