### PR TITLE
fix(db): use subscription id instead of index+1 to fetch servers in ListGet

### DIFF
--- a/service/db/listOp.go
+++ b/service/db/listOp.go
@@ -115,11 +115,12 @@ func ListGet(bucket string, key string, index int) (b []byte, err error) {
 		return []byte(configJSON), nil
 
 	case "touch/subscriptions":
+		var subID int64
 		var address, remarks, status, info string
 		var autoSelectInt int
 		err = db.QueryRow(
-			"SELECT address, remarks, status, info, auto_select FROM subscriptions WHERE sort = ?", index,
-		).Scan(&address, &remarks, &status, &info, &autoSelectInt)
+			"SELECT id, address, remarks, status, info, auto_select FROM subscriptions WHERE sort = ?", index,
+		).Scan(&subID, &address, &remarks, &status, &info, &autoSelectInt)
 		if err == sql.ErrNoRows {
 			return nil, fmt.Errorf("ListGet: can't get element from an empty list")
 		}
@@ -130,7 +131,7 @@ func ListGet(bucket string, key string, index int) (b []byte, err error) {
 		// Reconstruct the subscription JSON with servers
 		rows, err := db.Query(
 			"SELECT config_json FROM servers WHERE type = 'subscription_server' AND sub_id = ? ORDER BY sort",
-			int64(index+1),
+			subID,
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Problem

`ListGet("touch", "subscriptions", index)` fetches subscription servers with `sub_id = index+1`, but the `sub_id` column stores the subscription's row `id` (see `ListSet`, `ListRemove`, `ListGetAll`, which all query by row id). The row id can drift from `sort+1` because subscription updates delete and re-insert rows, incrementing `AUTOINCREMENT` ids while `sort` is renumbered from 0.

## Effect

When a subscription's row id differs from `sort+1` (e.g. `id=3, sort=0`), `GetLenSubscriptionServers()` returns 0 and `GetSubscription()` returns a subscription with an empty server list. This breaks:

- `GET /api/pingLatency`: `Whiches.GetNonDuplicated()` drops all subscription-server whiches, so the API returns an empty list immediately and the web UI is stuck at "testing..." forever for all subscription nodes.
- Anything else relying on `ListGet` for subscriptions.

The HTTP latency test is unaffected because it uses `GetSubscriptions()` (`ListGetAll`), which queries by row id.

## Fix

Select the subscription's row `id` in `ListGet` and use it for the servers query, consistent with `ListGetAll`/`ListSet`/`ListRemove`.

Verified against a real database where the subscription row is `id=3, sort=0` with 64 servers stored under `sub_id=3`: before the fix `GetLenSubscriptionServers(0)` returned 0 and ping returned an empty list; after the fix it returns 64 and `/api/pingLatency` returns measured latencies.
