### PR TITLE
fix(iptables): 为 DNS REDIRECT 规则补充协议参数

### DIFF
--- a/service/kernel/iptables/redirect.go
+++ b/service/kernel/iptables/redirect.go
@@ -21,6 +21,12 @@ type nftRedirect struct{}
 
 var Redirect redirect
 
+func legacyDNSRedirectTargetRules(command string) string {
+	return fmt.Sprintf(`%s -w 2 -t nat -A DNS_REDIRECT -p tcp -j REDIRECT --to-port 52353
+%s -w 2 -t nat -A DNS_REDIRECT -p udp -j REDIRECT --to-port 52353
+`, command, command)
+}
+
 func init() {
 	if IsNftablesSupported() {
 		Redirect = &nftRedirect{}
@@ -76,8 +82,7 @@ iptables -w 2 -t nat -A TP_RULE -d 240.0.0.0/4 -j RETURN
 iptables -w 2 -t nat -A TP_RULE -m mark --mark 0x80/0x80 -j RETURN
 # DNS 重定向到新 DNS 模块端口 52353（必须在通用 REDIRECT 规则之前）
 iptables -w 2 -t nat -A DNS_REDIRECT -m mark --mark 0x80/0x80 -j RETURN
-iptables -w 2 -t nat -A DNS_REDIRECT -j REDIRECT --to-port 52353
-`
+` + legacyDNSRedirectTargetRules("iptables")
 	for _, v := range GetExcludedInterfaces() {
 		commands += fmt.Sprintf("iptables -w 2 -t nat -A TP_RULE -i %s -j RETURN\n", strings.ReplaceAll(v, "*", "+"))
 	}
@@ -113,7 +118,7 @@ ip6tables -w 2 -t nat -N TP_PRE
 ip6tables -w 2 -t nat -N TP_RULE
 ip6tables -w 2 -t nat -N DNS_REDIRECT
 ip6tables -w 2 -t nat -A DNS_REDIRECT -m mark --mark 0x80/0x80 -j RETURN
-ip6tables -w 2 -t nat -A DNS_REDIRECT -j REDIRECT --to-port 52353
+` + legacyDNSRedirectTargetRules("ip6tables") + `
 ip6tables -w 2 -t nat -A TP_RULE -d ::/128 -j RETURN
 ip6tables -w 2 -t nat -A TP_RULE -d ::1/128 -j RETURN
 ip6tables -w 2 -t nat -A TP_RULE -d 64:ff9b::/96 -j RETURN

--- a/service/kernel/iptables/redirect_test.go
+++ b/service/kernel/iptables/redirect_test.go
@@ -1,0 +1,32 @@
+package iptables
+
+import "testing"
+
+func TestLegacyDNSRedirectTargetRules(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{
+			name:    "IPv4",
+			command: "iptables",
+			want: "iptables -w 2 -t nat -A DNS_REDIRECT -p tcp -j REDIRECT --to-port 52353\n" +
+				"iptables -w 2 -t nat -A DNS_REDIRECT -p udp -j REDIRECT --to-port 52353\n",
+		},
+		{
+			name:    "IPv6",
+			command: "ip6tables",
+			want: "ip6tables -w 2 -t nat -A DNS_REDIRECT -p tcp -j REDIRECT --to-port 52353\n" +
+				"ip6tables -w 2 -t nat -A DNS_REDIRECT -p udp -j REDIRECT --to-port 52353\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := legacyDNSRedirectTargetRules(tt.command); got != tt.want {
+				t.Fatalf("DNS REDIRECT 规则不符合预期:\n%s", got)
+			}
+		})
+	}
+}

--- a/service/kernel/v2ray/processManager.go
+++ b/service/kernel/v2ray/processManager.go
@@ -103,7 +103,9 @@ func (m *CoreProcessManager) CheckAndSetupTransparentProxy(checkRunning bool, se
 			}
 		}
 
-		err = writeTransparentProxyRules(tmpl)
+		if err = writeTransparentProxyRules(tmpl); err != nil {
+			return err
+		}
 
 		if thook := conf.GetEnvironmentConfig().TransparentHook; thook != "" {
 			hook := strings.Split(thook, " ")

--- a/service/kernel/v2ray/transparent.go
+++ b/service/kernel/v2ray/transparent.go
@@ -135,6 +135,13 @@ func deleteTransparentProxyRules() {
 	iptables.SystemProxy.GetCleanCommands().Run(false)
 }
 
+func runDNSRedirectCommands(commands string) error {
+	if err := cmds.ExecCommands(commands, false); err != nil {
+		return fmt.Errorf("failed to set up DNS redirect rules: %w", err)
+	}
+	return nil
+}
+
 func writeTransparentProxyRules(tmpl *Template) (err error) {
 	defer func() {
 		if err != nil {
@@ -209,7 +216,9 @@ ip6tables -w 2 -t nat -I OUTPUT -m mark --mark 0x80/0x80 -j RETURN
 ip6tables -w 2 -t nat -I PREROUTING -m mark --mark 0x80/0x80 -j RETURN
 `
 		}
-		cmds.ExecCommands(dnsRedirect, false)
+		if err = runDNSRedirectCommands(dnsRedirect); err != nil {
+			return err
+		}
 
 		if couldListenLocalhost, e := CouldLocalDnsListen(); couldListenLocalhost {
 			if e != nil {

--- a/service/kernel/v2ray/transparent_test.go
+++ b/service/kernel/v2ray/transparent_test.go
@@ -1,0 +1,9 @@
+package v2ray
+
+import "testing"
+
+func TestRunDNSRedirectCommandsReturnsError(t *testing.T) {
+	if err := runDNSRedirectCommands("exit 23"); err == nil {
+		t.Fatal("DNS 重定向命令失败时应返回错误")
+	}
+}


### PR DESCRIPTION
## 问题

iptables 模式会生成以下 DNS 重定向规则：

```text
iptables -t nat -A DNS_REDIRECT -j REDIRECT --to-port 52353
```

IPv6 规则也存在相同问题。

虽然 `PREROUTING` 和 `OUTPUT` 中跳转到 `DNS_REDIRECT` 的规则分别指定了 TCP、UDP，但 iptables 会独立校验每条规则。使用 `REDIRECT --to-port` 时，必须在同一条规则中指定协议。

当前规则在 iptables legacy 和 nf_tables 前端下都会报错：

```text
Need TCP, UDP, SCTP or DCCP with port specification
```

Docker 使用 `redirect` 透明代理时，防火墙配置因此失败。v2rayA 随后停止已经启动的核心，导致节点无法启动。

相关讨论：

https://github.com/v2rayA/v2rayA/discussions/1600

## 修改内容

- 分别生成 TCP、UDP 的 `DNS_REDIRECT` 规则。
- 同时修复 IPv4 和 IPv6。
- 后续直接 DNS 重定向规则执行失败时返回错误。
- 防火墙配置失败后不再执行透明代理 `post-start` hook。
- 添加 IPv4/IPv6 规则生成和命令错误处理测试。

## 验证

相关 Go 测试通过：

```text
go test ./kernel/iptables ./kernel/v2ray
```

使用 iptables 1.8.11 的 legacy 和 nf_tables 前端实际验证以下规则，均可成功添加：

```text
-A DNS_REDIRECT -p tcp -j REDIRECT --to-ports 52353
-A DNS_REDIRECT -p udp -j REDIRECT --to-ports 52353
```