### PR TITLE
fix: transparent proxy startup failure and DNS bootstrap deadlock

### DIFF
--- a/core/dns/upstream_stub.go
+++ b/core/dns/upstream_stub.go
@@ -94,7 +94,7 @@ func (m *UpstreamManager) exchangeDirect(upstream *UpstreamInstance, query *DnsQ
 	// checking if one already exists. Calling AddECSSubnet first then SetEdns0
 	// would create TWO OPT records in the query, causing FORMERR.
 	msg.SetEdns0(4096, true)
-	if query.ClientIP != nil {
+	if query.ClientIP != nil && query.ClientIP.IsGlobalUnicast() {
 		builder := NewResponseBuilder()
 		builder.AddECSSubnet(msg, query.ClientIP)
 	}
@@ -238,7 +238,7 @@ func (m *UpstreamManager) exchangeViaProxy(upstream *UpstreamInstance, query *Dn
 	// checking if one already exists. Calling AddECSSubnet first then SetEdns0
 	// would create TWO OPT records in the query, causing FORMERR.
 	msg.SetEdns0(4096, true)
-	if query.ClientIP != nil {
+	if query.ClientIP != nil && query.ClientIP.IsGlobalUnicast() {
 		builder := NewResponseBuilder()
 		builder.AddECSSubnet(msg, query.ClientIP)
 	}
@@ -557,7 +557,7 @@ func (m *UpstreamManager) exchangeViaDispatcher(upstream *UpstreamInstance, quer
 	// checking if one already exists. Calling AddECSSubnet first then SetEdns0
 	// would create TWO OPT records in the query, causing FORMERR.
 	msg.SetEdns0(4096, true)
-	if query.ClientIP != nil {
+	if query.ClientIP != nil && query.ClientIP.IsGlobalUnicast() {
 		builder := NewResponseBuilder()
 		builder.AddECSSubnet(msg, query.ClientIP)
 	}

--- a/service/kernel/iptables/redirect.go
+++ b/service/kernel/iptables/redirect.go
@@ -76,7 +76,8 @@ iptables -w 2 -t nat -A TP_RULE -d 240.0.0.0/4 -j RETURN
 iptables -w 2 -t nat -A TP_RULE -m mark --mark 0x80/0x80 -j RETURN
 # DNS 重定向到新 DNS 模块端口 52353（必须在通用 REDIRECT 规则之前）
 iptables -w 2 -t nat -A DNS_REDIRECT -m mark --mark 0x80/0x80 -j RETURN
-iptables -w 2 -t nat -A DNS_REDIRECT -j REDIRECT --to-port 52353
+iptables -w 2 -t nat -A DNS_REDIRECT -p tcp -j REDIRECT --to-port 52353
+iptables -w 2 -t nat -A DNS_REDIRECT -p udp -j REDIRECT --to-port 52353
 `
 	for _, v := range GetExcludedInterfaces() {
 		commands += fmt.Sprintf("iptables -w 2 -t nat -A TP_RULE -i %s -j RETURN\n", strings.ReplaceAll(v, "*", "+"))
@@ -113,7 +114,8 @@ ip6tables -w 2 -t nat -N TP_PRE
 ip6tables -w 2 -t nat -N TP_RULE
 ip6tables -w 2 -t nat -N DNS_REDIRECT
 ip6tables -w 2 -t nat -A DNS_REDIRECT -m mark --mark 0x80/0x80 -j RETURN
-ip6tables -w 2 -t nat -A DNS_REDIRECT -j REDIRECT --to-port 52353
+ip6tables -w 2 -t nat -A DNS_REDIRECT -p tcp -j REDIRECT --to-port 52353
+ip6tables -w 2 -t nat -A DNS_REDIRECT -p udp -j REDIRECT --to-port 52353
 ip6tables -w 2 -t nat -A TP_RULE -d ::/128 -j RETURN
 ip6tables -w 2 -t nat -A TP_RULE -d ::1/128 -j RETURN
 ip6tables -w 2 -t nat -A TP_RULE -d 64:ff9b::/96 -j RETURN

--- a/service/kernel/v2ray/template_core.go
+++ b/service/kernel/v2ray/template_core.go
@@ -109,7 +109,7 @@ func NewTemplate(serverInfos []serverInfo, setting *configure.Setting) (t *Templ
 	isTinyTunMode := setting.TransparentType == configure.TransparentTun && IsTransparentOn(setting)
 	if !isTinyTunMode {
 		//生成新 DNS 模块配置
-		if err = t.setDNS(); err != nil {
+		if err = t.setDNS(serverInfos); err != nil {
 			return nil, err
 		}
 	}

--- a/service/kernel/v2ray/template_dns.go
+++ b/service/kernel/v2ray/template_dns.go
@@ -70,15 +70,15 @@ type DnsRouting struct {
 
 // setDNS 生成新 DNS 模块的配置，嵌入 xray JSON 供 v2raya-core 读取。
 // v2raya-core 启动时解析此配置并启动独立 DNS 监听器，v2rayA 不参与 DNS 查询处理。
-func (t *Template) setDNS() error {
-	return t.generateDnsModuleConfig()
+func (t *Template) setDNS(serverInfos []serverInfo) error {
+	return t.generateDnsModuleConfig(serverInfos)
 }
 
 // generateDnsModuleConfig 生成新 DNS 模块的 JSON 配置，嵌入 xray JSON 配置文件。
 // v2raya-core 启动时解析此配置并启动独立 DNS 监听器，v2rayA 不参与 DNS 查询处理。
 //
 // 生成的配置结构对应 core/dns/config.go 中的 DnsModuleConfig。
-func (t *Template) generateDnsModuleConfig() error {
+func (t *Template) generateDnsModuleConfig(serverInfos []serverInfo) error {
 	setting := t.Setting
 	if setting == nil {
 		setting = configure.GetSettingNotNil()
@@ -332,6 +332,47 @@ func (t *Template) generateDnsModuleConfig() error {
 
 			rulesList = append(rulesList, rc)
 		}
+	}
+
+	// 节点服务器域名必须直连解析：若命中默认（代理）上游，查询经 dispatcher
+	// 路由到代理出站，而代理出站连接节点又需要解析节点域名，形成死锁，
+	// 导致节点域名永远解析失败、代理通道完全不可用。
+	var nodeDomains []string
+	for _, info := range serverInfos {
+		host := info.Info.GetHostname()
+		if host != "" && net.ParseIP(host) == nil {
+			nodeDomains = append(nodeDomains, host)
+		}
+	}
+	nodeDomains = common.Deduplicate(nodeDomains)
+	if len(nodeDomains) > 0 {
+		nodeUpstreamAddr := "223.5.5.5:53"
+		for _, s := range bootstrapDns {
+			if host, _, err := net.SplitHostPort(s); err == nil {
+				if ip := net.ParseIP(host); ip != nil && !ip.IsLoopback() {
+					nodeUpstreamAddr = s
+					break
+				}
+			}
+		}
+		// 不能 append 到末尾：模块以最后一个非 bootstrap 上游作为默认上游
+		upstreams = append([]map[string]interface{}{{
+			"id":        "upstream-node",
+			"addr":      nodeUpstreamAddr,
+			"protocol":  "udp",
+			"proxy_tag": "direct",
+			"bootstrap": false,
+		}}, upstreams...)
+		rulesList = append([]map[string]interface{}{{
+			"id":            "rule-node",
+			"upstream":      "upstream-node",
+			"action":        "route",
+			"policy":        "single",
+			"domain":        nil,
+			"domain_suffix": nodeDomains,
+			"ip":            nil,
+			"client_ip":     nil,
+		}}, rulesList...)
 	}
 
 	cfg["upstreams"] = upstreams


### PR DESCRIPTION
## Summary

Fixes three bugs on 2.4.15 that together broke the transparent proxy on legacy iptables:

1. **Startup failure** (`service/kernel/iptables/redirect.go`)
   The `DNS_REDIRECT` chain rules used `-j REDIRECT --to-port 52353` without a protocol match. iptables rejects this ("Need TCP, UDP, SCTP or DCCP with port specification"), so starting the core always aborted with `not support "redirect" mode of transparent proxy`.

2. **DNS bootstrap deadlock** (`service/kernel/v2ray/template_dns.go`, `template_core.go`)
   Proxy server domains (e.g. `cfyes.7770008.xyz`) fell through to the default DNS upstream, which is proxied. The upstream query is dispatched through the proxy outbound, but dialing that outbound requires resolving the server domain itself — a circular dependency leaving the whole proxy channel unusable (`dns read length via dispatcher: io: read/write on closed pipe`).
   Fix: generate a highest-priority DNS module rule routing all node server hostnames to a dedicated direct upstream (system DNS when available, fallback `223.5.5.5`). The upstream is *prepended* because the module treats the last non-bootstrap upstream as the default.

3. **ECS breaks split-horizon domains** (`core/dns/upstream_stub.go`)
   ECS was attached for any client address, including loopback/private ones (127.0.0.1 from the local listeners). RFC 7871 forbids non-globally-routable ECS addresses; with such ECS, AliDNS returned only the CNAME for Cloudflare-fronted server domains without the target A record, so those nodes could never resolve.
   Fix: attach ECS only when `ClientIP.IsGlobalUnicast()`.

## Verification

On a Debian host with legacy iptables v1.8.4:

- Clicking Start in the WebUI succeeds; `coreVersionValid: true`, kernel runs.
- Node domain resolution returns the full chain: `cfyes.7770008.xyz → CNAME cf2.yfjc.sbs → A 172.64.146.88`
- Foreign DNS via the proxied upstream (8.8.8.8) works.
- End-to-end: `curl https://www.google.com` through both the transparent proxy and the socks5 inbound returns 302; CN sites via the direct path return 200.