### PR TITLE
fix(gui): load outbound groups for custom inbound

### DIFF
--- a/gui/src/components/modalCustomInbound.vue
+++ b/gui/src/components/modalCustomInbound.vue
@@ -153,7 +153,7 @@ export default {
       });
     },
     fetchOutbounds() {
-      this.$axios({ url: apiRoot + "/outbound" }).then((res) => {
+      this.$axios({ url: apiRoot + "/outbounds" }).then((res) => {
         if (res.data.code === "SUCCESS") {
           this.outbounds = res.data.data.outbounds || [];
         }


### PR DESCRIPTION
## Problem

The "Bound outbound" selector in Custom Inbound Ports remains empty
even when outbound groups exist.

## Root cause

`modalCustomInbound.vue` requests `/api/outbound`, whose response
contains `data.setting`, but the component expects `data.outbounds`.

## Fix

Change the request endpoint from `/api/outbound` to `/api/outbounds`.

## Related discussions

- https://github.com/v2rayA/v2rayA/discussions/1907
- https://github.com/v2rayA/v2rayA/discussions/1926

## Testing

Not tested locally; relying on GitHub Actions for build validation.
The `/api/outbounds` endpoint was manually verified to return the
expected outbound group list.